### PR TITLE
Fix false positive diva reporting

### DIFF
--- a/src/telliot_feeds/cli/commands/report.py
+++ b/src/telliot_feeds/cli/commands/report.py
@@ -299,7 +299,7 @@ async def report(
             except KeyError:
                 click.echo(f"No corresponding datafeed found for query tag: {query_tag}\n")
                 return
-        elif reporting_diva_protocol is not None:
+        elif reporting_diva_protocol:
             if not valid_diva_chain(chain_id=cid):
                 click.echo("Diva Protocol not supported for this chain")
                 return


### PR DESCRIPTION
Fixes this:
```
(tenv) ubuntu@ip-fake:~$ telliot-feeds -a rinkeby3 report -p 101 -wp 120
...
Current chain id (4) not supported for reporting Diva Protocol data.
Diva Protocol not supported for this chain
```