### PR TITLE
Prepare for new release 0.1.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,11 +38,11 @@ jobs:
       if: "github.event.release.prerelease"
       uses: pypa/gh-action-pypi-publish@master
       with:
-        password: ${{ secrets.telliot_feeds_TEST_PYPI_API_TOKEN }}
+        password: ${{ secrets.TELLIOT_FEEDS_TEST_PYPI_API_TOKEN }}
         repository_url: https://test.pypi.org/legacy/
 
     - name: Publish telliot-feeds to PyPI
       if: "!github.event.release.prerelease"
       uses: pypa/gh-action-pypi-publish@master
       with:
-        password: ${{ secrets.telliot_feeds_PYPI_API_TOKEN }}
+        password: ${{ secrets.TELLIOT_FEEDS_PYPI_API_TOKEN }}

--- a/src/telliot_feeds/__init__.py
+++ b/src/telliot_feeds/__init__.py
@@ -6,4 +6,4 @@ registry = PluginRegistry()
 # registry.register_feed(btc_usd_median_feed)
 
 
-__version__ = "0.0.15dev0"
+__version__ = "0.1.0"


### PR DESCRIPTION
- Fixes the API keys for test & official pypi.org
- Bumps package version