### PR TITLE
rng error handling

### DIFF
--- a/src/telliot_feeds/sources/blockhash_aggregator.py
+++ b/src/telliot_feeds/sources/blockhash_aggregator.py
@@ -66,7 +66,13 @@ def block_num_from_timestamp(timestamp: int) -> Optional[int]:
             logger.error("Etherscan API returned JSON without status")
             return None
 
-        return int(this_block["result"])
+        try:
+            result = int(this_block["result"])
+        except ValueError:
+            logger.error("Etherscan API returned invalid block number")
+            return None
+
+        return result
 
 
 async def get_eth_hash(timestamp: int) -> Optional[str]:


### PR DESCRIPTION
<!-- Make sure that your title neatly summarizes the proposed changes -->

### Summary
<!-- Provide a short overview of the change and the value it adds -->
Fixes this bug: https://github.com/tellor-io/telliot-feeds/issues/300. Adds error handling to the RNG block_num_from_timestamp function. When the etherscan api returns a value which cannot be converted to an int, this fix will catch that error.

### Steps Taken to QA Changes
<!-- Describe the steps that you have taken to make sure that your changes work as intended without breaking other functionality. These steps should be reproducible and easy to follow for other QA testers-->


### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)
-->

This pull request is:

- [ ] A documentation error, docs update, or typographical error fix
	- No tests or issue needed
- [x] A code fix
	- Please reference the related issue by including "Closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a bug report issue 
	- Please include tests. Fixes without tests will not be accepted unless it's related to the documentation only.
    - Please make sure docs are updated if need be
- [ ] A feature implementation
	- Please reference the related issue by including "Closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a feature enhancement issue 
	- Please include tests
    - Please make sure docs updates are both thorough and easy to reproduce by somebody with limited knowledge of the feature that you are submitting


**Happy engineering!**