### PR TITLE
online method missing self arg

### DIFF
--- a/src/telliot_feeds/reporters/interval.py
+++ b/src/telliot_feeds/reporters/interval.py
@@ -292,7 +292,7 @@ class IntervalReporter:
         count, read_status = await self.oracle.read(func_name="getTimestampCountById", _queryId=query_id)
         return count, read_status
 
-    async def is_online() -> bool:
+    async def is_online(self) -> bool:
         return await is_online()
 
     async def report_once(

--- a/src/telliot_feeds/reporters/tellorflex.py
+++ b/src/telliot_feeds/reporters/tellorflex.py
@@ -362,7 +362,7 @@ class TellorFlexReporter(IntervalReporter):
         """Submit latest values to the TellorFlex oracle."""
 
         while True:
-            online = self.is_online()
+            online = await self.is_online()
             if online:
                 _, _ = await self.report_once()
             else:


### PR DESCRIPTION

### Summary
Minor fix: telliot was breaking because a method in interval.py was not given the "self" arg
https://github.com/tellor-io/telliot-feeds/blob/5ce625a0062f14b787923bf54b6a7c4bd4554c5d/src/telliot_feeds/reporters/interval.py#L295
Closes #356 
### Steps Taken to QA Changes
submitted txn using telliot: https://mumbai.polygonscan.com//tx/0x38cc45e8ea8b96bb92797c8277c1389b4749ae888a1e058ea6a91a8d96eb9eeb

### Checklist

This pull request is:

- [ ] A documentation error, docs update, or typographical error fix
	- No tests or issue needed
- [x] A code fix
	- Please reference the related issue by including "Closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a bug report issue 
	- Please include tests. Fixes without tests will not be accepted unless it's related to the documentation only.
    - Please make sure docs are updated if need be
- [ ] A feature implementation
	- Please reference the related issue by including "Closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a feature enhancement issue 
	- Please include tests
    - Please make sure docs updates are both thorough and easy to reproduce by somebody with limited knowledge of the feature that you are submitting


**Happy engineering!**