### PR TITLE
more specific type hints, value errors in Multicall

### DIFF
--- a/src/telliot_feeds/reporters/reporter_autopay_utils.py
+++ b/src/telliot_feeds/reporters/reporter_autopay_utils.py
@@ -498,7 +498,7 @@ async def _get_feed_suggestion(feeds: Any, current_values: Any) -> Any:
 
 async def safe_multicall(calls: List[Call], endpoint: Web3, require_success: bool) -> Optional[Dict[str, Any]]:
     """
-    Multcall...call with error handling
+    Multicall...call with error handling
 
     Args:
         calls: list of Call objects, representing calls made by request

--- a/tests/reporters/test_autopay_multicalls.py
+++ b/tests/reporters/test_autopay_multicalls.py
@@ -1,4 +1,6 @@
 """Test multicall success outcomes requirement True and False"""
+from unittest.mock import patch
+
 import pytest
 from multicall import Call
 from multicall import Multicall
@@ -6,6 +8,18 @@ from telliot_core.apps.core import TelliotCore
 from web3.exceptions import ContractLogicError
 
 from telliot_feeds.reporters.reporter_autopay_utils import AutopayCalls
+from telliot_feeds.reporters.reporter_autopay_utils import safe_multicall
+
+
+def fake_call(calls: AutopayCalls):
+    """helper function returning consistent fake multicall"""
+    return [
+        Call(
+            calls.autopay.address,
+            ["fakeFunction(bytes32)(uint256)", b""],
+            [["fake_key", None]],
+        )
+    ]
 
 
 @pytest.fixture
@@ -31,7 +45,7 @@ async def test_get_current_tips(setup_autopay_call):
 
 
 @pytest.mark.asyncio
-async def test_get_current_feeds(setup_autopay_call):
+async def test_get_current_feeds(caplog, setup_autopay_call):
     """Test getCurrentFeeds call in autopay using multicall"""
     calls: AutopayCalls = await setup_autopay_call
     # test proper function for success outcomes
@@ -45,21 +59,50 @@ async def test_get_current_feeds(setup_autopay_call):
     async def fake_function(require_success=True):
         """fake function signature call that doesn't exist in autopay
         should revert as a ContractLogicError"""
-        call = [
-            Call(
-                calls.autopay.address,
-                ["fakeFunction(bytes32)(uint256)", b""],
-                [["fake_key", None]],
-            )
-        ]
-        multi_call = Multicall(calls=call, _w3=calls.w3, require_success=require_success)
-        data = await multi_call.coroutine()
-        return data
+
+        return await safe_multicall(calls=fake_call(calls), endpoint=calls.w3, require_success=require_success)
 
     calls.get_current_feeds = fake_function
 
     tips = await calls.get_current_feeds(require_success=False)
     assert tips["fake_key"] is None
 
-    with pytest.raises(ContractLogicError):
-        await calls.get_current_feeds(require_success=True)
+    true_result = await calls.get_current_feeds(require_success=True)
+    assert true_result is None
+    assert "Contract reversion in multicall request" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_safe_multicall(caplog, setup_autopay_call):
+    """Test safe multicall with error handling"""
+    calls: AutopayCalls = await setup_autopay_call
+
+    def raise_unsupported_block_num():
+        raise ValueError({"code": -32000, "message": "unsupported block number 22071635"})
+
+    def raise_unexpected_rpc_error():
+        raise ValueError({"code": -32000, "message": "unexpected rpc error nooooo"})
+
+    def raise_contract_reversion():
+        raise ContractLogicError
+
+    with patch.object(Multicall, "coroutine", side_effect=raise_unsupported_block_num):
+
+        res = await safe_multicall(fake_call(calls), endpoint=calls.w3, require_success=True)
+
+        assert res is None
+        assert "ValueError" in caplog.text
+
+    with patch.object(Multicall, "coroutine", side_effect=raise_unexpected_rpc_error):
+
+        res = await safe_multicall(fake_call(calls), endpoint=calls.w3, require_success=True)
+
+        assert res is None
+        assert "ValueError" in caplog.text
+
+    with patch.object(Multicall, "coroutine", side_effect=raise_contract_reversion):
+
+        res = await safe_multicall(fake_call(calls), endpoint=calls.w3, require_success=True)
+
+        assert res is None
+        assert "Contract reversion in multicall request" in caplog.text

--- a/tests/reporters/test_autopay_multicalls.py
+++ b/tests/reporters/test_autopay_multicalls.py
@@ -29,10 +29,6 @@ async def test_get_current_tips(setup_autopay_call):
     tips = await calls.get_current_tip(require_success=False)
     assert tips["eth-usd-spot"] is None
 
-    with pytest.raises(ContractLogicError):
-        # If no tips are available in autopay getCurrentTip contract call reverts
-        await calls.get_current_tip(require_success=True)
-
 
 @pytest.mark.asyncio
 async def test_get_current_feeds(setup_autopay_call):


### PR DESCRIPTION
<!-- Make sure that your title neatly summarizes the proposed changes -->

### Summary
<!-- Provide a short overview of the change and the value it adds -->
Multicalls in this `reporter_autopay_utils` did not have error handling, so I added error handling for `ValueError`s for RPC errors and `web3.exceptions.ContractLogicError` for contract reversions.

I also added more specific type hints to the multicall functions.
### Steps Taken to QA Changes
<!-- Describe the steps that you have taken to make sure that your changes work as intended without breaking other functionality. These steps should be reproducible and easy to follow for other QA testers-->

- Ran pytest, removed expected raise of `ContractLogicError`
- Ran mypy to improve type hints

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)
-->

This pull request is:

- [ ] A documentation error, docs update, or typographical error fix
	- No tests or issue needed
- [x] A code fix
	- Please reference the related issue by including "Closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a bug report issue 
	- Please include tests. Fixes without tests will not be accepted unless it's related to the documentation only.
    - Please make sure docs are updated if need be
- [ ] A feature implementation
	- Please reference the related issue by including "Closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a feature enhancement issue 
	- Please include tests
    - Please make sure docs updates are both thorough and easy to reproduce by somebody with limited knowledge of the feature that you are submitting

Closes #339
**Happy engineering!**