### PR TITLE
fix failing test with similar error 364/365

### DIFF
--- a/src/telliot_feeds/reporters/reporter_autopay_utils.py
+++ b/src/telliot_feeds/reporters/reporter_autopay_utils.py
@@ -151,7 +151,12 @@ class AutopayCalls:
             return None
 
         # separate items from current feeds
-        # create dict of tag and feed_id in current_feeds
+        # multicall for multiple different functions returns different types of data at once
+        # ie the response is {"tag": (feedids, ), ('trb-usd-legacy', 'current_time'): 0,
+        # ('trb-usd-legacy', 'three_mos_ago'): 0,eth-jpy-legacy: (),'eth-jpy-legacy', 'current_time'): 0,
+        # ('eth-jpy-legacy', 'three_mos_ago'): 0}
+        # here we filter out the tag key if it is string and its value is of length > 0
+
         tags_with_feed_ids = {
             tag: feed_id
             for tag, feed_id in current_feeds.items()

--- a/src/telliot_feeds/reporters/reporter_autopay_utils.py
+++ b/src/telliot_feeds/reporters/reporter_autopay_utils.py
@@ -234,7 +234,7 @@ class AutopayCalls:
         feed_details_before_check = await self.get_feed_details()
         if not feed_details_before_check:
             logger.info("No feeds balance to check")
-            return None
+            return None, None, None
         # create a key to use for the first timestamp since it doesn't have a before value that needs to be checked
         feed_details_before_check[(0, 0)] = 0
         timestamp_before_key = (0, 0)
@@ -368,7 +368,7 @@ async def get_continuous_tips(autopay: TellorFlexAutopayContract, tipping_feeds:
     if tipping_feeds is None:
         tipping_feeds = AutopayCalls(autopay=autopay, catalog=CATALOG_QUERY_IDS)
     response = await tipping_feeds.reward_claim_status()
-    if not response:
+    if response == (None, None, None):
         logger.info("No feeds to check")
         return None
     current_feeds, current_values, claim_status = response


### PR DESCRIPTION
<!-- Make sure that your title neatly summarizes the proposed changes -->
### Summary
fixes in this issue #339 had breaking changes causing the tests/test_autopay.py test to fail similar to #364 and #365 so the code was amended and the test is passing.  Researched the original issue #339 and the reason for that is documented here [Arbitrum Dev Center](https://developer.offchainlabs.com/time).  Basically arbitrum block numbers are produced differently than ethereum and so the multicall contract call errored.  There is an arbitrum multicall contract on mainnet Arbitrum but couldn't find a testnet address so deployed and verified ([Link](https://testnet.arbiscan.io/address/0xb84C5c81A9774722701d751bd3D2c0f19bfC25fa#code)) the mainnet contract on testnet and added the address in telliot_feeds.

closes #364
closes #365
### Steps Taken to QA Changes
- ran both tests concerning reporter_autopay_utils.py and they pass locally,
  - tests/test_autopay.py
  - tests/reporters/test_autopay_multicall.py

### Checklist
This pull request is:

- [ ] A documentation error, docs update, or typographical error fix
	- No tests or issue needed
- [ ] A code fix
	- Please reference the related issue by including "Closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a bug report issue 
	- Please include tests. Fixes without tests will not be accepted unless it's related to the documentation only.
    - Please make sure docs are updated if need be
- [ ] A feature implementation
	- Please reference the related issue by including "Closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a feature enhancement issue 
	- Please include tests
    - Please make sure docs updates are both thorough and easy to reproduce by somebody with limited knowledge of the feature that you are submitting


**Happy engineering!**