### PR TITLE
Add RNG source for auto value input to ```DATAFEED_BUILDER_MAPPING```

### DIFF
--- a/src/telliot_feeds/feeds/__init__.py
+++ b/src/telliot_feeds/feeds/__init__.py
@@ -31,6 +31,7 @@ from telliot_feeds.feeds.snapshot_feed import snapshot_manual_feed
 from telliot_feeds.feeds.spot_price_manual_feed import spot_price_manual_feed
 from telliot_feeds.feeds.string_query_feed import string_query_feed
 from telliot_feeds.feeds.sushi_usd_feed import sushi_usd_median_feed
+from telliot_feeds.feeds.tellor_rng_feed import tellor_rng_feed
 from telliot_feeds.feeds.tellor_rng_manual_feed import tellor_rng_manual_feed
 from telliot_feeds.feeds.trb_usd_feed import trb_usd_median_feed
 from telliot_feeds.feeds.trb_usd_legacy_feed import trb_usd_legacy_feed
@@ -89,6 +90,7 @@ DATAFEED_BUILDER_MAPPING: Dict[str, DataFeed[Any]] = {
     "LegacyRequest": legacy_request_manual_feed,
     "TWAP": twap_manual_feed,
     "DailyVolatility": daily_volatility_manual_feed,
-    "TellorRNG": tellor_rng_manual_feed,
+    "TellorRNG": tellor_rng_feed,
+    "TellorRNGManualResponse": tellor_rng_manual_feed,
     # "morphware",
 }


### PR DESCRIPTION
### Summary
<!-- Provide a short overview of the change and the value it adds -->
- Added RNG source for auto value input to ```DATAFEED_BUILDER_MAPPING```.  Currently the source available in ```DATAFEED_BUILDER_MAPPING``` requires a manual value input which could be useful if the Apis are down for some reason.  The source already exists in telliot-feeds, so just added it to the mapping.
### Steps Taken to QA Changes
Submitted a transaction going through the process of reporting through the ```--build-flag```.  [Transaction Link](https://mumbai.polygonscan.com/tx/0xbdb0407494cafe3f22418909fccc1cf208cf4042c98e2dce52cce0c2c3880565)

### Checklist

This pull request is:

- [ ] A documentation error, docs update, or typographical error fix
	- No tests or issue needed
- [ ] A code fix
	- Please reference the related issue by including "Closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a bug report issue 
	- Please include tests. Fixes without tests will not be accepted unless it's related to the documentation only.
    - Please make sure docs are updated if need be
- [x] A feature implementation
	- Please reference the related issue by including "Closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a feature enhancement issue 
	- Please include tests
    - Please make sure docs updates are both thorough and easy to reproduce by somebody with limited knowledge of the feature that you are submitting


**Happy engineering!**