### PR TITLE
Remove high level diva-specific prompts

### DIFF
--- a/src/telliot_feeds/cli/commands/report.py
+++ b/src/telliot_feeds/cli/commands/report.py
@@ -260,7 +260,7 @@ def reporter() -> None:
     type=click.UNPROCESSED,
     callback=validate_address,
     default=DIVA_DIAMOND_ADDRESS,
-    prompt=True,
+    prompt=False,
 )
 @click.option(
     "--diva-middleware-address",
@@ -271,7 +271,7 @@ def reporter() -> None:
     type=click.UNPROCESSED,
     callback=validate_address,
     default=DIVA_TELLOR_MIDDLEWARE_ADDRESS,
-    prompt=True,
+    prompt=False,
 )
 @click.option(
     "--custom-contract",


### PR DESCRIPTION
<!-- Make sure that your title neatly summarizes the proposed changes -->

### Summary
<!-- Provide a short overview of the change and the value it adds -->
Previously, the CLI would ask the user to confirm the contract addresses for the DIVA Protocol integration even if they weren't reporting for that query type. This removes those automatic prompts.

### Steps Taken to QA Changes
<!-- Describe the steps that you have taken to make sure that your changes work as intended without breaking other functionality. These steps should be reproducible and easy to follow for other QA testers-->
Ran the `report` command and it doesn't prompt for DIVA addresses.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)
-->

This pull request is:

- [ ] A documentation error, docs update, or typographical error fix
	- No tests or issue needed
- [ ] A code fix
	- Please reference the related issue by including "Closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a bug report issue 
	- Please include tests. Fixes without tests will not be accepted unless it's related to the documentation only.
    - Please make sure docs are updated if need be
- [ ] A feature implementation
	- Please reference the related issue by including "Closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a feature enhancement issue 
	- Please include tests
    - Please make sure docs updates are both thorough and easy to reproduce by somebody with limited knowledge of the feature that you are submitting


**Happy engineering!**