### PR TITLE
Fix ability to stake more

### DIFF
--- a/src/telliot_feeds/reporters/tellor_360.py
+++ b/src/telliot_feeds/reporters/tellor_360.py
@@ -48,12 +48,12 @@ class StakerInfo:
 
 
 class Tellor360Reporter(TellorFlexReporter):
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        kwargs["stake"]: float = 0
+    def __init__(self, stake: float = 0, *args: Any, **kwargs: Any) -> None:
         self.stake_amount: Optional[int] = None
         self.staker_info: Optional[StakerInfo] = None
         self.allowed_stake_amount = 0
         super().__init__(*args, **kwargs)
+        self.stake: float = stake
 
         logger.info(f"Reporting with account: {self.acct_addr}")
 

--- a/tests/reporters/test_360reporter.py
+++ b/tests/reporters/test_360reporter.py
@@ -10,7 +10,7 @@ txn_kwargs = {"gas_limit": 3500000, "legacy_gas_price": 1}
 
 
 @pytest_asyncio.fixture(scope="function")
-async def reporter_360(mumbai_test_cfg, tellorflex_360_contract, mock_autopay_contract, mock_token_contract):
+async def tellor_360(mumbai_test_cfg, tellorflex_360_contract, mock_autopay_contract, mock_token_contract):
     async with TelliotCore(config=mumbai_test_cfg) as core:
 
         account = core.get_account()
@@ -25,33 +25,31 @@ async def reporter_360(mumbai_test_cfg, tellorflex_360_contract, mock_autopay_co
         tellor360.oracle.connect()
         tellor360.token.connect()
         tellor360.autopay.connect()
-        tellor360 = core.get_tellor360_contracts()
-
-        r = Tellor360Reporter(
-            oracle=tellor360.oracle,
-            token=tellor360.token,
-            autopay=tellor360.autopay,
-            endpoint=core.endpoint,
-            account=account,
-            chain_id=80001,
-            transaction_type=0,
-        )
 
         # mint token and send to reporter address
-        mock_token_contract.mint(account.address, 1000e18)
+        mock_token_contract.mint(account.address, 100000e18)
 
         # send eth from brownie address to reporter address for txn fees
         accounts[1].transfer(account.address, "1 ether")
         # init governance address
         await tellor360.oracle.write("init", _governanceAddress=accounts[0].address, **txn_kwargs)
 
-        return r
+        return tellor360, account
 
 
 @pytest.mark.asyncio
-async def test_report(reporter_360, caplog):
+async def test_report(tellor_360, caplog):
     """Test 360 reporter deposit and balance changes when stakeAmount changes"""
-    r: Tellor360Reporter = reporter_360
+    contracts, account = tellor_360
+    r = Tellor360Reporter(
+        oracle=contracts.oracle,
+        token=contracts.token,
+        autopay=contracts.autopay,
+        endpoint=contracts.oracle.node,
+        account=account,
+        chain_id=80001,
+        transaction_type=0,
+    )
 
     await r.report_once()
     assert r.staker_info.stake_balance == int(1e18)
@@ -80,3 +78,39 @@ async def test_report(reporter_360, caplog):
 
     await r.report_once()
     assert "Currently in reporter lock. Time left: 5:59" in caplog.text  # 6hr
+
+
+@pytest.mark.asyncio
+async def test_adding_stake(tellor_360):
+    """Test 360 reporter depositing more stake"""
+    contracts, account = tellor_360
+    reporter_kwargs = {
+        "oracle": contracts.oracle,
+        "token": contracts.token,
+        "autopay": contracts.autopay,
+        "endpoint": contracts.oracle.node,
+        "account": account,
+        "chain_id": 80001,
+        "transaction_type": 0,
+    }
+    reporter = Tellor360Reporter(**reporter_kwargs)
+
+    # check stake amount
+    stake_amount, status = await reporter.oracle.read("getStakeAmount")
+    assert status.ok
+    assert stake_amount == int(1e18), "Should be 1e18"
+
+    # check default stake value
+    assert reporter.stake == 0
+
+    # first should deposits default stake
+    _, status = await reporter.report_once()
+    assert status.ok
+    assert reporter.staker_info.stake_balance == int(1e18), "Staker balance should be 1e18"
+
+    # stake more by by changing stake from default similar to how a stake amount chosen in cli
+    # high stake to bypass reporter lock
+    reporter = Tellor360Reporter(**reporter_kwargs, stake=90000)
+    _, status = await reporter.report_once()
+    assert status.ok
+    assert reporter.staker_info.stake_balance == pytest.approx(90000e18), "Staker balance should be 90000e18"


### PR DESCRIPTION
### Summary
- Staking the chosen amount at cli was broken by a previous change I made so fixed it.  Now you should be able to stake more based on the chosen amount at cli. Closes #409 

### Steps Taken to QA Changes
- Added a test thats passing locally as well as depositing more stake than required through the cli.  [Txn](https://mumbai.polygonscan.com//tx/0x6cfdc44c65841e822bc9484deb31ce6b90aaa1ff8d7ed04efed14332724cf1f8)

### Checklist

This pull request is:

- [ ] A documentation error, docs update, or typographical error fix
	- No tests or issue needed
- [x] A code fix
	- Please reference the related issue by including Closes #409 in this Pull Request's summary section. 
        - If no issue exists, please create a bug report issue 
	- Please include tests. Fixes without tests will not be accepted unless it's related to the documentation only.
    - Please make sure docs are updated if need be
- [ ] A feature implementation
	- Please reference the related issue by including "Closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a feature enhancement issue 
	- Please include tests
    - Please make sure docs updates are both thorough and easy to reproduce by somebody with limited knowledge of the feature that you are submitting


**Happy engineering!**