### PR TITLE
Fix bug causing txn type choice to be overridden

### DIFF
--- a/src/telliot_feeds/cli/commands/report.py
+++ b/src/telliot_feeds/cli/commands/report.py
@@ -485,8 +485,6 @@ async def report(
                 contracts.autopay.address = autopay_address
                 contracts.autopay.connect()
 
-            # Type 2 transactions unsupported currently
-            common_reporter_kwargs["transaction_type"] = 0
             # set additional common kwargs to shorten code
             common_reporter_kwargs["oracle"] = contracts.oracle
             common_reporter_kwargs["autopay"] = contracts.autopay


### PR DESCRIPTION
### Summary
- Removed a line on commands/report.py that was causing the transaction type selection to be overridden.
- Closes #422 

### Steps Taken to QA Changes
Submitted a transaction on mumbai where I couldn't find docs on if EIP-1559 was implemented. Although there is this forum [Link](https://forum.polygon.technology/t/eip1559-implementation-on-mumbai-testnet/399).
[Transaction Link Mumbai](https://mumbai.polygonscan.com/tx/0x098749961a11fb87f32f06c2250a51b0d033c52ca447db4eb9c748ab47da307d)
Mainnet-Eth, Görli, and Polygon-mainnet all have EIP-1559 implemented so there shouldn't be an issue with submitting type 2 transactions

### Checklist

This pull request is:

- [ ] A documentation error, docs update, or typographical error fix
	- No tests or issue needed
- [x] A code fix
	- Please reference the related issue by including "Closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a bug report issue 
	- Please include tests. Fixes without tests will not be accepted unless it's related to the documentation only.
    - Please make sure docs are updated if need be
- [ ] A feature implementation
	- Please reference the related issue by including "Closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a feature enhancement issue 
	- Please include tests
    - Please make sure docs updates are both thorough and easy to reproduce by somebody with limited knowledge of the feature that you are submitting


**Happy engineering!**