### PR TITLE
Add integrations cmd, add DIVA clear/view cache cmd

### DIFF
--- a/src/telliot_feeds/cli/commands/integrations.py
+++ b/src/telliot_feeds/cli/commands/integrations.py
@@ -1,0 +1,12 @@
+import click
+
+from telliot_feeds.integrations.diva_protocol.cli import diva
+
+
+@click.group()
+def integrations() -> None:
+    """Commands for Tellor Protocol integrations."""
+    pass
+
+
+integrations.add_command(diva)

--- a/src/telliot_feeds/cli/main.py
+++ b/src/telliot_feeds/cli/main.py
@@ -9,6 +9,7 @@ from chained_accounts import find_accounts
 from click.core import Context
 
 from telliot_feeds.cli.commands.catalog import catalog
+from telliot_feeds.cli.commands.integrations import integrations
 from telliot_feeds.cli.commands.query import query
 from telliot_feeds.cli.commands.report import report
 from telliot_feeds.cli.commands.settle import settle
@@ -65,6 +66,7 @@ main.add_command(report)
 main.add_command(query)
 main.add_command(catalog)
 main.add_command(settle)
+main.add_command(integrations)
 
 if __name__ == "__main__":
     main()

--- a/src/telliot_feeds/integrations/diva_protocol/cli.py
+++ b/src/telliot_feeds/integrations/diva_protocol/cli.py
@@ -1,0 +1,40 @@
+import click
+
+from telliot_feeds.integrations.diva_protocol.utils import get_reported_pools, update_reported_pools
+
+
+@click.group()
+def diva() -> None:
+    """Commands for Diva Protocol integration."""
+    pass
+
+
+@diva.group()
+def cache() -> None:
+    """Commands for interacting with reported/settled pools cache (pickle file)."""
+    pass
+
+
+@cache.command()
+def view() -> None:
+    """View reported/settled pools cache."""
+    cache = get_reported_pools()
+    if cache:
+        click.echo("Reported/Settled Pools Cache:")
+    else:
+        click.echo("Reported/Settled Pools Cache is empty")
+        return
+    for pool_id in cache:
+        click.echo(f"Pool ID: {pool_id}")
+        expiry, status = cache[pool_id]
+        click.echo(f"\tExpiry: {expiry}")
+        click.echo(f"\tSettle status: {status}")
+
+
+@cache.command()
+def clear() -> None:
+    """Clear reported/settled pools cache.
+
+    Creates and saves an empty dict as a pickle file in the telliot default dir."""
+    update_reported_pools({})
+    click.echo("Cleared reported/settled pools cache")

--- a/src/telliot_feeds/integrations/diva_protocol/cli.py
+++ b/src/telliot_feeds/integrations/diva_protocol/cli.py
@@ -1,6 +1,7 @@
 import click
 
-from telliot_feeds.integrations.diva_protocol.utils import get_reported_pools, update_reported_pools
+from telliot_feeds.integrations.diva_protocol.utils import get_reported_pools
+from telliot_feeds.integrations.diva_protocol.utils import update_reported_pools
 
 
 @click.group()

--- a/tests/cli/test_diva_cli.py
+++ b/tests/cli/test_diva_cli.py
@@ -42,9 +42,26 @@ def test_default_values_available():
         assert result.exit_code == 0
 
 
-def test_integrations_help_cmd():
-    # ensure diva cmd is available
-    pass
+def test_available_cmds():
+    """Test help command for integrations."""
+    runner = CliRunner()
+    result = runner.invoke(cli_main, ["integrations", "--help"])
+
+    assert result.exit_code == 0
+    assert "diva  Commands for Diva Protocol integration." in result.stdout
+
+    result = runner.invoke(cli_main, ["integrations", "diva", "--help"])
+
+    assert result.exit_code == 0
+    assert "Commands for interacting with reported/settled pools cache" in result.stdout
+
+    result = runner.invoke(cli_main, ["integrations", "diva", "cache", "--help"])
+    view_msg = "view   View reported/settled pools cache."
+    clear_msg = "clear  Clear reported/settled pools cache."
+
+    assert result.exit_code == 0
+    assert view_msg in result.stdout
+    assert clear_msg in result.stdout
 
 
 def test_diva_help_cmd():


### PR DESCRIPTION
<!-- Make sure that your title neatly summarizes the proposed changes -->

### Summary
<!-- Provide a short overview of the change and the value it adds -->
- Closes #435 
- Adds commands to view/clear local cache of reported/settled pools:
```console
$ telliot-feeds integrations diva cache --help
Usage: telliot-feeds integrations diva cache [OPTIONS] COMMAND [ARGS]...

  Commands for interacting with reported/settled pools cache (pickle file).

Options:
  --help  Show this message and exit.

Commands:
  clear  Clear reported/settled pools cache.
  view   View reported/settled pools cache.
  ```

### Steps Taken to QA Changes
<!-- Describe the steps that you have taken to make sure that your changes work as intended without breaking other functionality. These steps should be reproducible and easy to follow for other QA testers-->
- `update_reported_pools` function already tested, so just added tests for the newly available commands. And did some sanity checks on my machine to make sure cmds works.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)
-->

This pull request is:

- [ ] A documentation error, docs update, or typographical error fix
	- No tests or issue needed
- [ ] A code fix
	- Please reference the related issue by including "Closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a bug report issue 
	- Please include tests. Fixes without tests will not be accepted unless it's related to the documentation only.
    - Please make sure docs are updated if need be
- [x] A feature implementation
	- Please reference the related issue by including "Closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a feature enhancement issue 
	- Please include tests
    - Please make sure docs updates are both thorough and easy to reproduce by somebody with limited knowledge of the feature that you are submitting


**Happy engineering!**