### PR TITLE
Use input w/ timeout for snapshot & rng manual sources

### DIFF
--- a/src/telliot_feeds/feeds/snapshot_feed.py
+++ b/src/telliot_feeds/feeds/snapshot_feed.py
@@ -7,7 +7,7 @@ https://github.com/tellor-io/dataSpecs/blob/main/types/Snapshot.md
 """
 from telliot_feeds.datafeed import DataFeed
 from telliot_feeds.queries.snapshot import Snapshot
-from telliot_feeds.sources.manual_input_source import ManualSnapshotInputSource
+from telliot_feeds.sources.manual.snapshot import ManualSnapshotInputSource
 
 proposalId = None
 

--- a/tests/sources/test_tellor_rng_source.py
+++ b/tests/sources/test_tellor_rng_source.py
@@ -4,7 +4,6 @@ from unittest import mock
 import pytest
 import requests
 
-from telliot_feeds.sources import blockhash_aggregator
 from telliot_feeds.sources.blockhash_aggregator import get_btc_hash
 from telliot_feeds.sources.blockhash_aggregator import get_eth_hash
 from telliot_feeds.sources.blockhash_aggregator import TellorRNGManualSource
@@ -13,14 +12,15 @@ from telliot_feeds.sources.blockhash_aggregator import TellorRNGManualSource
 @pytest.mark.asyncio
 async def test_rng():
     """Retrieve random number."""
-    blockhash_aggregator.input = lambda: "1652075943"  # BCT block num: 731547
-    rng_source = TellorRNGManualSource()
-    v, t = await rng_source.fetch_new_datapoint()
+    # "1652075943"  # BCT block num: 731547
+    with mock.patch("telliot_feeds.utils.input_timeout.InputTimeout.__call__", side_effect=["1652075943", ""]):
+        rng_source = TellorRNGManualSource()
+        v, t = await rng_source.fetch_new_datapoint()
 
-    assert v == b"\x9diF\xd9R\xf1>q%\x13F\x11\xad\x9f]\xccA\x08\xd9\x03Y\xb0#\x94\xd8\xefgi\xcc\x85t\xb3"
+        assert v == b"\x9diF\xd9R\xf1>q%\x13F\x11\xad\x9f]\xccA\x08\xd9\x03Y\xb0#\x94\xd8\xefgi\xcc\x85t\xb3"
 
-    assert isinstance(v, bytes)
-    assert isinstance(t, datetime)
+        assert isinstance(v, bytes)
+        assert isinstance(t, datetime)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
<!-- Make sure that your title neatly summarizes the proposed changes -->

### Summary
<!-- Provide a short overview of the change and the value it adds -->
- Missed 2 sources (snapshot & rng) that needed implementation of input w/ timeout, closes #507 

### Steps Taken to QA Changes
<!-- Describe the steps that you have taken to make sure that your changes work as intended without breaking other functionality. These steps should be reproducible and easy to follow for other QA testers-->
- TeStEd lOcAlLy:
```console
$ /Users/owen/tellor/telliot-feeds/env/bin/python /Users
/owen/tellor/telliot-feeds/src/telliot_feeds/sources/blockhash_aggregator.py
Enter timestamp for generating a random number: 
12341234
Generating random number from timestamp: 12341234
Press [ENTER] to confirm.

WARNING | __main__ | Blockchain.info API returned no blocks
WARNING | __main__ | Unable to retrieve Bitcoin blockhash
datapoint: None None
```

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)
-->

This pull request is:

- [ ] A documentation error, docs update, or typographical error fix
	- No tests or issue needed
- [ ] A code fix
	- Please reference the related issue by including "Closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a bug report issue 
	- Please include tests. Fixes without tests will not be accepted unless it's related to the documentation only.
    - Please make sure docs are updated if need be
- [x] A feature implementation
	- Please reference the related issue by including "Closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a feature enhancement issue 
	- Please include tests
    - Please make sure docs updates are both thorough and easy to reproduce by somebody with limited knowledge of the feature that you are submitting


**Happy engineering!**