### PR TITLE
Added function to check if timestamp is valid

### DIFF
--- a/src/telliot_feeds/reporters/tips/listener/tip_listener_filter.py
+++ b/src/telliot_feeds/reporters/tips/listener/tip_listener_filter.py
@@ -44,9 +44,6 @@ class TipListenerFilter:
         """
         qtyp_name = self.decode_typ_name(qdata)
 
-        if qtyp_name == "TellorRNG":
-            return False
-
         return qtyp_name in Registry.registry
 
     def qtag_from_feed_catalog(self, qdata: bytes) -> Optional[str]:

--- a/src/telliot_feeds/sources/blockhash_aggregator.py
+++ b/src/telliot_feeds/sources/blockhash_aggregator.py
@@ -197,12 +197,11 @@ class TellorRNGManualSource(DataSource[Any]):
             _ = datetime.fromtimestamp(timestamp)
             # Timestamp should >= ethereum genesis block timestamp
             if timestamp >= 1438284388:
+                return True
+            else:
                 logger.info(
                     f"Invalid timestamp: {timestamp}, should be greater than 1438284388 (eth genesis block timestamp)"
                 )
-                return True
-            else:
-                logger.info("Timestamp is valid but less than 123 seconds")
                 return False
         except ValueError:
             logger.info(f"Invalid timestamp: {timestamp}")

--- a/src/telliot_feeds/sources/blockhash_aggregator.py
+++ b/src/telliot_feeds/sources/blockhash_aggregator.py
@@ -190,14 +190,31 @@ class TellorRNGManualSource(DataSource[Any]):
         self.timestamp = data
         return data
 
+    def is_valid_timestamp(self, timestamp: int) -> bool:
+        """Check if timestamp is valid."""
+        try:
+            # Checking if timestamp is valid first
+            _ = datetime.fromtimestamp(timestamp)
+            # Timestamp should >= ethereum genesis block timestamp
+            if timestamp >= 1438284388:
+                logger.info(
+                    f"Invalid timestamp: {timestamp}, should be greater than 1438284388 (eth genesis block timestamp)"
+                )
+                return True
+            else:
+                logger.info("Timestamp is valid but less than 123 seconds")
+                return False
+        except ValueError:
+            logger.info(f"Invalid timestamp: {timestamp}")
+            return False
+
     async def fetch_new_datapoint(self) -> OptionalDataPoint[bytes]:
         """Update current value with time-stamped value fetched from user input.
 
         Returns:
             Current time-stamped value
         """
-
-        if self.timestamp == 0:
+        if not self.is_valid_timestamp(self.timestamp):
             try:
                 timestamp = self.parse_user_val()
             except TimeoutOccurred:

--- a/src/telliot_feeds/sources/blockhash_aggregator.py
+++ b/src/telliot_feeds/sources/blockhash_aggregator.py
@@ -179,6 +179,8 @@ class TellorRNGManualSource(DataSource[Any]):
 
             try:
                 inpt = int(inpt)
+                if not self.is_valid_timestamp(inpt):
+                    continue
             except ValueError:
                 print("Invalid input. Enter decimal value (int).")
                 continue
@@ -196,11 +198,11 @@ class TellorRNGManualSource(DataSource[Any]):
             # Checking if timestamp is valid first
             _ = datetime.fromtimestamp(timestamp)
             # Timestamp should >= ethereum genesis block timestamp
-            if timestamp >= 1438284388:
+            if timestamp >= 1438269973:
                 return True
             else:
                 logger.info(
-                    f"Invalid timestamp: {timestamp}, should be greater than 1438284388 (eth genesis block timestamp)"
+                    f"Invalid timestamp: {timestamp}, should be greater than 1438269973 (eth genesis block timestamp)"
                 )
                 return False
         except ValueError:

--- a/src/telliot_feeds/sources/blockhash_aggregator.py
+++ b/src/telliot_feeds/sources/blockhash_aggregator.py
@@ -1,4 +1,5 @@
 import asyncio
+import time
 from dataclasses import dataclass
 from datetime import datetime
 from datetime import timezone
@@ -195,18 +196,18 @@ class TellorRNGManualSource(DataSource[Any]):
     def is_valid_timestamp(self, timestamp: int) -> bool:
         """Check if timestamp is valid."""
         try:
-            # Checking if timestamp is valid first
             _ = datetime.fromtimestamp(timestamp)
-            # Timestamp should >= ethereum genesis block timestamp
-            if timestamp >= 1438269973:
-                return True
-            else:
-                logger.info(
-                    f"Invalid timestamp: {timestamp}, should be greater than 1438269973 (eth genesis block timestamp)"
-                )
-                return False
         except ValueError:
             logger.info(f"Invalid timestamp: {timestamp}")
+            return False
+
+        if 1438269973 <= timestamp <= int(time.time()):
+            return True
+        else:
+            logger.info(
+                f"Invalid timestamp: {timestamp}, should be greater than eth genesis block timestamp"
+                "and less than current time"
+            )
             return False
 
     async def fetch_new_datapoint(self) -> OptionalDataPoint[bytes]:

--- a/tests/feeds/test_manual_snapshot_feed.py
+++ b/tests/feeds/test_manual_snapshot_feed.py
@@ -7,15 +7,17 @@ from telliot_feeds.utils.log import get_logger
 
 logger = get_logger(__name__)
 
+input_timeout = "telliot_feeds.sources.manual.snapshot.input_timeout"
+
 
 @pytest.mark.asyncio
 async def test_valid_user_nput(monkeypatch):
-    monkeypatch.setattr("builtins.input", lambda: "n")
+    monkeypatch.setattr(input_timeout, lambda: "n")
     val, _ = await snapshot_manual_feed.source.fetch_new_datapoint()
     assert isinstance(val, bool)
     assert val is False
 
-    monkeypatch.setattr("builtins.input", lambda: "y")
+    monkeypatch.setattr(input_timeout, lambda: "y")
     (val, _) = await snapshot_manual_feed.source.fetch_new_datapoint()
     assert isinstance(val, bool)
     assert val is True
@@ -23,7 +25,7 @@ async def test_valid_user_nput(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_bad_user_input():
-    with mock.patch("builtins.input", side_effect=["", "not a bool", "y", ""]):
+    with mock.patch(input_timeout, side_effect=["", "not a bool", "y", ""]):
         (val, _) = await snapshot_manual_feed.source.fetch_new_datapoint()
         assert type(val) is bool
         assert val is True


### PR DESCRIPTION
### Summary
Closes #506 
This is happening because of someone tipping TellorRNG query in autopay with an invalid timestamp.
- added a function that checks the timestamp and prompts the reporter to manually input a valid timestamp that the apis can return a value for.

### Steps Taken to QA Changes
- Added test that mocks an invalid timestamp
- tipped autopay with an invalid timestamp -> [Txn](https://mumbai.polygonscan.com/tx/0x04c5b4d7b0f1698e8b0a314b2c2cd4d63a528adb7ceefbca822cef521c18e7d7)
- submitted transaction thru telliot that required a manually entry -> [Txn](https://mumbai.polygonscan.com/tx/0x0f999682c1a141deed18ddf7140c93eab9a91178bdf32d5464f04f41b50ed38b)

### Checklist

This pull request is:

- [ ] A documentation error, docs update, or typographical error fix
	- No tests or issue needed
- [x] A code fix
	- Please reference the related issue by including "Closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a bug report issue 
	- Please include tests. Fixes without tests will not be accepted unless it's related to the documentation only.
    - Please make sure docs are updated if need be
- [ ] A feature implementation
	- Please reference the related issue by including "Closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a feature enhancement issue 
	- Please include tests
    - Please make sure docs updates are both thorough and easy to reproduce by somebody with limited knowledge of the feature that you are submitting


**Happy engineering!**