### PR TITLE
add ETH/BTC median feed

### DIFF
--- a/src/telliot_feeds/feeds/__init__.py
+++ b/src/telliot_feeds/feeds/__init__.py
@@ -9,6 +9,7 @@ from telliot_feeds.feeds.btc_usd_feed import btc_usd_median_feed
 from telliot_feeds.feeds.dai_usd_feed import dai_usd_median_feed
 from telliot_feeds.feeds.daily_volatility_manual_feed import daily_volatility_manual_feed
 from telliot_feeds.feeds.diva_manual_feed import diva_manual_feed
+from telliot_feeds.feeds.eth_btc_feed import eth_btc_median_feed
 from telliot_feeds.feeds.eth_jpy_feed import eth_jpy_median_feed
 from telliot_feeds.feeds.eth_usd_30day_volatility import eth_usd_30day_volatility
 from telliot_feeds.feeds.eth_usd_feed import eth_usd_median_feed
@@ -70,6 +71,7 @@ CATALOG_FEEDS = {
     "albt-usd-spot": albt_usd_median_feed,
     "rai-usd-spot": rai_usd_median_feed,
     "xdai-usd-spot": xdai_usd_median_feed,
+    "eth-btc-spot": eth_btc_median_feed,
 }
 
 DATAFEED_BUILDER_MAPPING: Dict[str, DataFeed[Any]] = {

--- a/src/telliot_feeds/feeds/eth_btc_feed.py
+++ b/src/telliot_feeds/feeds/eth_btc_feed.py
@@ -1,0 +1,22 @@
+from telliot_feeds.datafeed import DataFeed
+from telliot_feeds.queries.price.spot_price import SpotPrice
+from telliot_feeds.sources.price.spot.binance import BinanceSpotPriceSource
+from telliot_feeds.sources.price.spot.coinbase import CoinbaseSpotPriceSource
+from telliot_feeds.sources.price.spot.coingecko import CoinGeckoSpotPriceSource
+from telliot_feeds.sources.price.spot.gemini import GeminiSpotPriceSource
+from telliot_feeds.sources.price_aggregator import PriceAggregator
+
+eth_btc_median_feed = DataFeed(
+    query=SpotPrice(asset="ETH", currency="BTC"),
+    source=PriceAggregator(
+        asset="eth",
+        currency="btc",
+        algorithm="median",
+        sources=[
+            CoinGeckoSpotPriceSource(asset="eth", currency="btc"),
+            BinanceSpotPriceSource(asset="eth", currency="btc"),
+            CoinbaseSpotPriceSource(asset="eth", currency="btc"),
+            GeminiSpotPriceSource(asset="eth", currency="btc"),
+        ],
+    ),
+)

--- a/src/telliot_feeds/queries/price/spot_price.py
+++ b/src/telliot_feeds/queries/price/spot_price.py
@@ -13,7 +13,7 @@ from telliot_feeds.queries.abi_query import AbiQuery
 
 logger = logging.getLogger(__name__)
 
-CURRENCIES = ["usd", "jpy", "eth"]
+CURRENCIES = ["usd", "jpy", "eth", "btc"]
 SPOT_PRICE_PAIRS = [
     "ETH/USD",
     "BTC/USD",
@@ -34,6 +34,7 @@ SPOT_PRICE_PAIRS = [
     "ALBT/USD",
     "RAI/USD",
     "XDAI/USD",
+    "ETH/BTC",
 ]
 
 

--- a/src/telliot_feeds/queries/query_catalog.py
+++ b/src/telliot_feeds/queries/query_catalog.py
@@ -168,3 +168,9 @@ query_catalog.add_entry(
     title="XDAI/USD spot price",
     q=SpotPrice(asset="xdai", currency="usd"),
 )
+
+query_catalog.add_entry(
+    tag="eth-btc-spot",
+    title="ETH/BTC spot price",
+    q=SpotPrice(asset="eth", currency="btc"),
+)

--- a/tests/feeds/test_eth_btc_feed.py
+++ b/tests/feeds/test_eth_btc_feed.py
@@ -1,0 +1,24 @@
+import statistics
+
+import pytest
+
+from telliot_feeds.feeds.eth_btc_feed import eth_btc_median_feed
+
+
+@pytest.mark.asyncio
+async def test_eth_btc_median_feed(caplog):
+    """Retrieve median ETH/USD price."""
+    v, _ = await eth_btc_median_feed.source.fetch_new_datapoint()
+
+    assert v is not None
+    assert v > 0
+    assert (
+        "sources used in aggregate: 4" in caplog.text.lower() or "sources used in aggregate: 5" in caplog.text.lower()
+    )
+    print(f"ETH/USD Price: {v}")
+
+    # Get list of data sources from sources dict
+    source_prices = [source.latest[0] for source in eth_btc_median_feed.source.sources if source.latest[0]]
+
+    # Make sure error is less than decimal tolerance
+    assert (v - statistics.median(source_prices)) < 10**-6

--- a/tests/feeds/test_eth_btc_feed.py
+++ b/tests/feeds/test_eth_btc_feed.py
@@ -7,15 +7,15 @@ from telliot_feeds.feeds.eth_btc_feed import eth_btc_median_feed
 
 @pytest.mark.asyncio
 async def test_eth_btc_median_feed(caplog):
-    """Retrieve median ETH/USD price."""
+    """Retrieve median ETH/BTC price."""
     v, _ = await eth_btc_median_feed.source.fetch_new_datapoint()
 
     assert v is not None
     assert v > 0
-    assert (
-        "sources used in aggregate: 4" in caplog.text.lower() or "sources used in aggregate: 5" in caplog.text.lower()
+    assert (  # sometimes only 3 sources are used bc binance restricts locations
+        "sources used in aggregate: 4" in caplog.text.lower() or "sources used in aggregate: 3" in caplog.text.lower()
     )
-    print(f"ETH/USD Price: {v}")
+    print(f"ETH/BTC Price: {v}")
 
     # Get list of data sources from sources dict
     source_prices = [source.latest[0] for source in eth_btc_median_feed.source.sources if source.latest[0]]


### PR DESCRIPTION
### Summary
This pull request will add an ETH/BTC feed for Badger that takes the median value for eth/btc when pulled from 4 sources: CoinGecko, Binance, Coinbase, and Gemini.

This pull request is:

- [ ] A documentation error, docs update, or typographical error fix
	- No tests or issue needed
- [ ] A code fix
	- Please reference the related issue by including "Closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a bug report issue 
	- Please include tests. Fixes without tests will not be accepted unless it's related to the documentation only.
    - Please make sure docs are updated if need be
- [X] A feature implementation
	- Please reference the related issue by including "Closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a feature enhancement issue 
	- Please include tests
    - Please make sure docs updates are both thorough and easy to reproduce by somebody with limited knowledge of the feature that you are submitting
