### PR TITLE
Fix encoding error

### DIFF
--- a/src/telliot_feeds/reporters/tellor_360.py
+++ b/src/telliot_feeds/reporters/tellor_360.py
@@ -6,6 +6,7 @@ from typing import Any
 from typing import Optional
 from typing import Tuple
 
+from eth_abi.exceptions import EncodingTypeError
 from eth_utils import to_checksum_address
 from telliot_core.utils.response import error_status
 from telliot_core.utils.response import ResponseStatus
@@ -198,7 +199,13 @@ class Tellor360Reporter(TellorFlexReporter):
         total_rewards: int = 0
 
         if self.datafeed is not None:
-            fetch_autopay_tip = await fetch_feed_tip(self.autopay, self.datafeed.query.query_id)
+            try:
+                qid = self.datafeed.query.query_id
+                fetch_autopay_tip = await fetch_feed_tip(self.autopay, qid)
+            except EncodingTypeError:
+                logger.warning("Unable to generate query data/id for datafeed")
+                fetch_autopay_tip = 0
+
             if fetch_autopay_tip is not None:
                 total_rewards += fetch_autopay_tip
 

--- a/src/telliot_feeds/reporters/tellor_360.py
+++ b/src/telliot_feeds/reporters/tellor_360.py
@@ -203,8 +203,7 @@ class Tellor360Reporter(TellorFlexReporter):
                 qid = self.datafeed.query.query_id
                 fetch_autopay_tip = await fetch_feed_tip(self.autopay, qid)
             except EncodingTypeError:
-                logger.warning("Unable to generate query data/id for datafeed")
-                fetch_autopay_tip = 0
+                logger.warning(f"Unable to generate data/id for query: {self.datafeed.query}")
 
             if fetch_autopay_tip is not None:
                 total_rewards += fetch_autopay_tip

--- a/src/telliot_feeds/reporters/tellor_flex.py
+++ b/src/telliot_feeds/reporters/tellor_flex.py
@@ -8,6 +8,7 @@ from typing import Tuple
 from typing import Union
 
 from chained_accounts import ChainedAccount
+from eth_abi.exceptions import EncodingTypeError
 from eth_utils import to_checksum_address
 from telliot_core.contract.contract import Contract
 from telliot_core.gas.legacy_gas import legacy_gas_station
@@ -236,8 +237,13 @@ class TellorFlexReporter(IntervalReporter):
         if query tag is selected fetches the rewards, if any, for that query tag"""
         if self.datafeed:
             # add query id to catalog to fetch tip for legacy autopay
-            if self.datafeed.query.query_id not in CATALOG_QUERY_IDS:
-                CATALOG_QUERY_IDS[self.datafeed.query.query_id] = self.datafeed.query.descriptor
+            try:
+                qid = self.datafeed.query.query_id
+            except EncodingTypeError:
+                logger.warning("Unable to generate query data/id for datafeed")
+                return None
+            if qid not in CATALOG_QUERY_IDS:
+                CATALOG_QUERY_IDS[qid] = self.datafeed.query.descriptor
             self.autopaytip = await self.rewards()
             return self.datafeed
 

--- a/src/telliot_feeds/reporters/tellor_flex.py
+++ b/src/telliot_feeds/reporters/tellor_flex.py
@@ -240,7 +240,7 @@ class TellorFlexReporter(IntervalReporter):
             try:
                 qid = self.datafeed.query.query_id
             except EncodingTypeError:
-                logger.warning("Unable to generate query data/id for datafeed")
+                logger.warning(f"Unable to generate data/id for query: {self.datafeed.query}")
                 return None
             if qid not in CATALOG_QUERY_IDS:
                 CATALOG_QUERY_IDS[qid] = self.datafeed.query.descriptor

--- a/tests/queries/test_query_support.py
+++ b/tests/queries/test_query_support.py
@@ -24,3 +24,14 @@ def test_all_query_types_in_catalog():
     for q in JsonQuery.__subclasses__():
         print("Checking", q.__name__)
         assert q.__name__ in q_types
+
+
+def test_gen_all_query_ids():
+    """Test that all query IDs can be generated."""
+    for q in AbiQuery.__subclasses__():
+        print("Checking", q.__name__)
+        q.query_id
+
+    for q in JsonQuery.__subclasses__():
+        print("Checking", q.__name__)
+        q.query_id

--- a/tests/reporters/test_360_reporter.py
+++ b/tests/reporters/test_360_reporter.py
@@ -267,4 +267,4 @@ async def test_fail_gen_query_id(tellor_360, monkeypatch, caplog, guaranteed_pri
     reporter = Tellor360Reporter(**reporter_kwargs)
     _ = await reporter.rewards()
 
-    assert "Unable to generate query data/id for datafeed" in caplog.text
+    assert "Unable to generate data/id for query" in caplog.text


### PR DESCRIPTION
<!-- Make sure that your title neatly summarizes the proposed changes -->

### Summary
<!-- Provide a short overview of the change and the value it adds -->
- Closes #584 
- Setting a query parameter's value to a type that's not encodable given the abi type will reproduce the error; however, I do not know why this happened given Spuddy's original command. When would the reporter have a datafeed with a query that has incorrect parameter values?

### Steps Taken to QA Changes
<!-- Describe the steps that you have taken to make sure that your changes work as intended without breaking other functionality. These steps should be reproducible and easy to follow for other QA testers-->
- Added tests to reproduce error & check if handled (see Files Changed tab)
- [report tx](https://goerli.etherscan.io/tx/0x5de859ca32feb5e5612ccbe4978c5a15af5c94516dc9e49dae231a73a76c6c2e) using command Spuddy used that produced the error originally (excluding the stake 10000 part)
### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)
-->

This pull request is:

- [ ] A documentation error, docs update, or typographical error fix
	- No tests or issue needed
- [x] A code fix
	- Please reference the related issue by including "Closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a bug report issue 
	- Please include tests. Fixes without tests will not be accepted unless it's related to the documentation only.
    - Please make sure docs are updated if need be
- [ ] A feature implementation
	- Please reference the related issue by including "Closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a feature enhancement issue 
	- Please include tests
    - Please make sure docs updates are both thorough and easy to reproduce by somebody with limited knowledge of the feature that you are submitting


**Happy engineering!**