### PR TITLE
removed bitfinex from ALBT-USD

### DIFF
--- a/src/telliot_feeds/feeds/albt_usd_feed.py
+++ b/src/telliot_feeds/feeds/albt_usd_feed.py
@@ -2,7 +2,6 @@ import asyncio
 
 from telliot_feeds.datafeed import DataFeed
 from telliot_feeds.queries.price.spot_price import SpotPrice
-from telliot_feeds.sources.price.spot.bitfinex import BitfinexSpotPriceSource
 from telliot_feeds.sources.price.spot.coingecko import CoinGeckoSpotPriceSource
 from telliot_feeds.sources.price.spot.coinmarketcap import (
     CoinMarketCapSpotPriceSource,
@@ -18,7 +17,6 @@ albt_usd_median_feed = DataFeed(
         sources=[
             CoinGeckoSpotPriceSource(asset="albt", currency="usd"),
             CoinMarketCapSpotPriceSource(asset="albt", currency="usd"),
-            BitfinexSpotPriceSource(asset="albt:", currency="usd"),
         ],
     ),
 )


### PR DESCRIPTION
This pull request will remove the bitfinex source from ALBT. Trading seems to be frozen on most exchanges, so the only good sources right now are coingecko and coinmarketcap.