### PR TITLE
Use web3 for gas calculations usage/price

### DIFF
--- a/src/telliot_feeds/cli/commands/report.py
+++ b/src/telliot_feeds/cli/commands/report.py
@@ -1,4 +1,3 @@
-import getpass
 from typing import Any
 from typing import Optional
 
@@ -321,13 +320,6 @@ async def report(
         return
 
     ctx.obj["CHAIN_ID"] = accounts[0].chains[0]  # used in reporter_cli_core
-
-    if signature_account is not None:
-        try:
-            if not signature_password:
-                signature_password = getpass.getpass(f"Enter password for {signature_account} keyfile: ")
-        except ValueError:
-            click.echo("Invalid Password")
 
     # Initialize telliot core app using CLI context
     async with reporter_cli_core(ctx) as core:

--- a/src/telliot_feeds/cli/utils.py
+++ b/src/telliot_feeds/cli/utils.py
@@ -29,13 +29,12 @@ def print_reporter_settings(
     signature_address: str,
     query_tag: str,
     gas_limit: int,
-    priority_fee: Optional[int],
+    priority_fee: Optional[float],
     expected_profit: str,
     chain_id: int,
     max_fee: Optional[int],
     transaction_type: int,
     legacy_gas_price: Optional[int],
-    gas_price_speed: str,
     reporting_diva_protocol: bool,
     stake_amount: float,
     min_native_token_balance: float,
@@ -66,7 +65,6 @@ def print_reporter_settings(
     click.echo(f"Legacy gas price (gwei): {legacy_gas_price}")
     click.echo(f"Max fee (gwei): {max_fee}")
     click.echo(f"Priority fee (gwei): {priority_fee}")
-    click.echo(f"Gas price speed: {gas_price_speed}")
     click.echo(f"Desired stake amount: {stake_amount}")
     click.echo(f"Minimum native token balance (e.g. ETH if on Ethereum mainnet): {min_native_token_balance}")
     click.echo("\n")

--- a/src/telliot_feeds/cli/utils.py
+++ b/src/telliot_feeds/cli/utils.py
@@ -32,7 +32,7 @@ def print_reporter_settings(
     priority_fee: Optional[float],
     expected_profit: str,
     chain_id: int,
-    max_fee: Optional[int],
+    max_fee: Optional[float],
     transaction_type: int,
     legacy_gas_price: Optional[int],
     reporting_diva_protocol: bool,

--- a/src/telliot_feeds/integrations/diva_protocol/report.py
+++ b/src/telliot_feeds/integrations/diva_protocol/report.py
@@ -279,18 +279,16 @@ class DIVAProtocolReporter(Tellor360Reporter):
 
         # Add transaction type 2 (EIP-1559) data
         if self.transaction_type == 2:
-            logger.info(f"maxFeePerGas: {self.max_fee}")
-            logger.info(f"maxPriorityFeePerGas: {self.priority_fee}")
+            priority_fee, max_fee = self.get_fee_info()
+            if priority_fee is None or max_fee is None:
+                return None, error_status("Unable to suggest type 2 txn fees", log=logger.error)
 
             built_submit_val_tx = submit_val_tx.buildTransaction(
                 {
                     "nonce": acc_nonce,
                     "gas": gas_limit,
-                    "maxFeePerGas": Web3.toWei(self.max_fee, "gwei"),
-                    # TODO: Investigate more why etherscan txs using Flashbots have
-                    # the same maxFeePerGas and maxPriorityFeePerGas. Example:
-                    # https://etherscan.io/tx/0x0bd2c8b986be4f183c0a2667ef48ab1d8863c59510f3226ef056e46658541288 # noqa: E501
-                    "maxPriorityFeePerGas": Web3.toWei(self.priority_fee, "gwei"),  # noqa: E501
+                    "maxFeePerGas": Web3.toWei(max_fee, "gwei"),
+                    "maxPriorityFeePerGas": Web3.toWei(priority_fee, "gwei"),
                     "chainId": self.chain_id,
                 }
             )

--- a/src/telliot_feeds/integrations/diva_protocol/report.py
+++ b/src/telliot_feeds/integrations/diva_protocol/report.py
@@ -146,13 +146,14 @@ class DIVAProtocolReporter(Tellor360Reporter):
     async def settle_pool(self, pool_id: int) -> ResponseStatus:
         """Settle pool"""
         if not self.legacy_gas_price:
-            gas_price = await self.fetch_gas_price(self.gas_price_speed)
+            gas_price = await self.fetch_gas_price()
             if not gas_price:
                 msg = "Unable to fetch gas price for tx type 0"
                 return error_status(note=msg, log=logger.warning)
         else:
             gas_price = self.legacy_gas_price
 
+        gas_price = int(gas_price) if gas_price >= 1 else 1
         status = await self.set_final_ref_value(pool_id=pool_id, gas_price=gas_price)
         if status is not None and status.ok:
             logger.info(f"Pool {pool_id} settled.")
@@ -267,6 +268,11 @@ class DIVAProtocolReporter(Tellor360Reporter):
             _nonce=report_count,
             _queryData=query_data,
         )
+        # Estimate gas usage amount
+        gas_limit, status = self.submit_val_tx_gas_limit(submit_val_tx=submit_val_tx)
+        if not status.ok or gas_limit is None:
+            return None, status
+
         acc_nonce, nonce_status = self.get_acct_nonce()
         if not nonce_status.ok:
             return None, nonce_status
@@ -279,8 +285,8 @@ class DIVAProtocolReporter(Tellor360Reporter):
             built_submit_val_tx = submit_val_tx.buildTransaction(
                 {
                     "nonce": acc_nonce,
-                    "gas": self.gas_limit,
-                    "maxFeePerGas": Web3.toWei(self.max_fee, "gwei"),  # type: ignore
+                    "gas": gas_limit,
+                    "maxFeePerGas": Web3.toWei(self.max_fee, "gwei"),
                     # TODO: Investigate more why etherscan txs using Flashbots have
                     # the same maxFeePerGas and maxPriorityFeePerGas. Example:
                     # https://etherscan.io/tx/0x0bd2c8b986be4f183c0a2667ef48ab1d8863c59510f3226ef056e46658541288 # noqa: E501
@@ -292,8 +298,8 @@ class DIVAProtocolReporter(Tellor360Reporter):
         else:
             # Fetch legacy gas price if not provided by user
             if not self.legacy_gas_price:
-                gas_price = await self.fetch_gas_price(self.gas_price_speed)
-                if not gas_price:
+                gas_price = await self.fetch_gas_price()
+                if gas_price is None:
                     note = "Unable to fetch gas price for tx type 0"
                     return None, error_status(note, log=logger.warning)
             else:
@@ -302,7 +308,7 @@ class DIVAProtocolReporter(Tellor360Reporter):
             built_submit_val_tx = submit_val_tx.buildTransaction(
                 {
                     "nonce": acc_nonce,
-                    "gas": self.gas_limit,
+                    "gas": gas_limit,
                     "gasPrice": Web3.toWei(gas_price, "gwei"),
                     "chainId": self.chain_id,
                 }

--- a/src/telliot_feeds/reporters/custom_reporter.py
+++ b/src/telliot_feeds/reporters/custom_reporter.py
@@ -40,8 +40,8 @@ class CustomXReporter(IntervalReporter):
         expected_profit: Union[str, float] = 100.0,
         transaction_type: int = 0,
         gas_limit: Optional[int] = None,
-        max_fee: int = 0,
-        priority_fee: float = 0.0,
+        max_fee: Optional[float] = None,
+        priority_fee: Optional[float] = None,
         legacy_gas_price: Optional[int] = None,
     ) -> None:
 
@@ -188,16 +188,9 @@ class CustomXReporter(IntervalReporter):
 
         # Add transaction type 2 (EIP-1559) data
         if self.transaction_type == 2:
-            if not self.max_fee:
-                fee_info = await self.get_fee_info()
-                if fee_info[0] is None:
-                    return None, error_status("Unable to suggestFees", log=logger.error)
-                base_fee = fee_info[0].suggestBaseFee
-                priority_fee = fee_info[0].SafeGasPrice if not self.priority_fee else self.priority_fee
-                max_fee = int(self.priority_fee + base_fee)
-            else:
-                max_fee = self.max_fee
-                priority_fee = self.priority_fee
+            priority_fee, max_fee = self.get_fee_info()
+            if priority_fee is None or max_fee is None:
+                return None, error_status("Unable to suggest type 2 txn fees", log=logger.error)
 
             # Set gas price to max fee used for profitability check
             self.gas_info["type"] = 2

--- a/src/telliot_feeds/reporters/flashbot.py
+++ b/src/telliot_feeds/reporters/flashbot.py
@@ -111,16 +111,9 @@ class FlashbotsReporter(Tellor360Reporter):
 
         # Add transaction type 2 (EIP-1559) data
         if self.transaction_type == 2:
-            if not self.max_fee:
-                fee_info = await self.get_fee_info()
-                if fee_info[0] is None:
-                    return None, error_status("Unable to suggest fees for type 2 txn", log=logger.error)
-                base_fee = fee_info[0].suggestBaseFee
-                priority_fee = fee_info[0].SafeGasPrice if not self.priority_fee else self.priority_fee
-                max_fee = int(priority_fee + base_fee)
-            else:
-                max_fee = self.max_fee
-                priority_fee = self.priority_fee
+            priority_fee, max_fee = self.get_fee_info()
+            if priority_fee is None or max_fee is None:
+                return None, error_status("Unable to suggest type 2 txn fees", log=logger.error)
 
             logger.info(f"maxFeePerGas: {max_fee}")
             logger.info(f"maxPriorityFeePerGas: {priority_fee}")

--- a/src/telliot_feeds/reporters/flashbot.py
+++ b/src/telliot_feeds/reporters/flashbot.py
@@ -117,7 +117,7 @@ class FlashbotsReporter(Tellor360Reporter):
                     return None, error_status("Unable to suggest fees for type 2 txn", log=logger.error)
                 base_fee = fee_info[0].suggestBaseFee
                 priority_fee = fee_info[0].SafeGasPrice if not self.priority_fee else self.priority_fee
-                max_fee = int(self.priority_fee + base_fee)
+                max_fee = int(priority_fee + base_fee)
             else:
                 max_fee = self.max_fee
                 priority_fee = self.priority_fee

--- a/src/telliot_feeds/reporters/flashbot.py
+++ b/src/telliot_feeds/reporters/flashbot.py
@@ -65,12 +65,6 @@ class FlashbotsReporter(Tellor360Reporter):
 
         logger.info(f"Current query: {datafeed.query.descriptor}")
 
-        status = await self.ensure_profitable(datafeed)
-        if not status.ok:
-            return None, status
-
-        status = ResponseStatus()
-
         # Update datafeed value
         await datafeed.source.fetch_new_datapoint()
         latest_data = datafeed.source.latest
@@ -104,37 +98,76 @@ class FlashbotsReporter(Tellor360Reporter):
             _nonce=timestamp_count,
             _queryData=query_data,
         )
+        # Estimate gas usage amount
+        gas_limit, status = self.submit_val_tx_gas_limit(submit_val_tx=submit_val_tx)
+        if not status.ok or gas_limit is None:
+            return None, status
+
+        self.gas_info["gas_limit"] = gas_limit
+        # Get account nonce
         acc_nonce, nonce_status = self.get_acct_nonce()
         if not nonce_status.ok:
             return None, nonce_status
 
         # Add transaction type 2 (EIP-1559) data
         if self.transaction_type == 2:
-            logger.info(f"maxFeePerGas: {self.max_fee}")
-            logger.info(f"maxPriorityFeePerGas: {self.priority_fee}")
+            if not self.max_fee:
+                fee_info = await self.get_fee_info()
+                if fee_info[0] is None:
+                    return None, error_status("Unable to suggest fees for type 2 txn", log=logger.error)
+                base_fee = fee_info[0].suggestBaseFee
+                priority_fee = fee_info[0].SafeGasPrice if not self.priority_fee else self.priority_fee
+                max_fee = int(self.priority_fee + base_fee)
+            else:
+                max_fee = self.max_fee
+                priority_fee = self.priority_fee
+
+            logger.info(f"maxFeePerGas: {max_fee}")
+            logger.info(f"maxPriorityFeePerGas: {priority_fee}")
+
+            # Set gas price to max fee used for profitability check
+            self.gas_info["type"] = 2
+            self.gas_info["max_fee"] = max_fee
+            self.gas_info["priority_fee"] = priority_fee
+            self.gas_info["base_fee"] = max_fee - priority_fee
 
             built_submit_val_tx = submit_val_tx.buildTransaction(
                 {
                     "nonce": acc_nonce,
-                    "gas": self.gas_limit,
-                    "maxFeePerGas": Web3.toWei(self.max_fee, "gwei"),  # type: ignore
+                    "gas": gas_limit,
+                    "maxFeePerGas": Web3.toWei(max_fee, "gwei"),
                     # TODO: Investigate more why etherscan txs using Flashbots have
                     # the same maxFeePerGas and maxPriorityFeePerGas. Example:
                     # https://etherscan.io/tx/0x0bd2c8b986be4f183c0a2667ef48ab1d8863c59510f3226ef056e46658541288 # noqa: E501
-                    "maxPriorityFeePerGas": Web3.toWei(self.priority_fee, "gwei"),  # noqa: E501
+                    "maxPriorityFeePerGas": Web3.toWei(priority_fee, "gwei"),  # noqa: E501
                     "chainId": self.chain_id,
                 }
             )
         # Add transaction type 0 (legacy) data
         else:
+            if not self.legacy_gas_price:
+                gas_price = await self.fetch_gas_price()
+                if gas_price is None:
+                    note = "Unable to fetch gas price for tx type 0"
+                    return None, error_status(note, log=logger.warning)
+            else:
+                gas_price = self.legacy_gas_price
+
+            self.gas_info["type"] = 0
+            self.gas_info["gas_price"] = gas_price
             built_submit_val_tx = submit_val_tx.buildTransaction(
                 {
                     "nonce": acc_nonce,
-                    "gas": self.gas_limit,
-                    "gasPrice": Web3.toWei(self.legacy_gas_price, "gwei"),  # type: ignore
+                    "gas": gas_limit,
+                    "gasPrice": Web3.toWei(gas_price, "gwei"),
                     "chainId": self.chain_id,
                 }
             )
+
+        status = await self.ensure_profitable(datafeed)
+        if not status.ok:
+            return None, status
+        status = ResponseStatus()
 
         submit_val_tx_signed = self.account.sign_transaction(built_submit_val_tx)  # type: ignore
 

--- a/src/telliot_feeds/reporters/interval.py
+++ b/src/telliot_feeds/reporters/interval.py
@@ -114,7 +114,7 @@ class IntervalReporter:
         return status
 
     async def fetch_gas_price(self) -> Optional[float]:
-        """Fetches the current gas price from the Ethereum network and returns
+        """Fetches the current gas price from an EVM network and returns
         an adjusted gas price.
 
         Returns:
@@ -458,8 +458,6 @@ class IntervalReporter:
         status = await self.ensure_profitable(datafeed)
         if not status.ok:
             return None, status
-        # TODO: double check if this is needed
-        status = ResponseStatus()
 
         lazy_unlock_account(self.account)
         local_account = self.account.local_account

--- a/src/telliot_feeds/reporters/interval.py
+++ b/src/telliot_feeds/reporters/interval.py
@@ -11,23 +11,25 @@ from typing import Union
 from chained_accounts import ChainedAccount
 from eth_utils import to_checksum_address
 from telliot_core.contract.contract import Contract
-from telliot_core.gas.legacy_gas import legacy_gas_station
 from telliot_core.model.endpoints import RPCEndpoint
 from telliot_core.utils.key_helpers import lazy_unlock_account
 from telliot_core.utils.response import error_status
 from telliot_core.utils.response import ResponseStatus
-from web3 import Web3
+from web3.contract import ContractFunction
 from web3.datastructures import AttributeDict
 
 from telliot_feeds.datafeed import DataFeed
+from telliot_feeds.dtypes.datapoint import OptionalDataPoint
 from telliot_feeds.feeds import CATALOG_FEEDS
 from telliot_feeds.feeds.eth_usd_feed import eth_usd_median_feed
 from telliot_feeds.feeds.trb_usd_feed import trb_usd_median_feed
+from telliot_feeds.sources.etherscan_gas import EtherscanGasPrice
 from telliot_feeds.sources.etherscan_gas import EtherscanGasPriceSource
 from telliot_feeds.utils.log import get_logger
 from telliot_feeds.utils.reporter_utils import has_native_token_funds
 from telliot_feeds.utils.reporter_utils import is_online
 from telliot_feeds.utils.reporter_utils import tellor_suggested_report
+from telliot_feeds.utils.reporter_utils import tkn_symbol
 
 
 logger = get_logger(__name__)
@@ -47,11 +49,11 @@ class IntervalReporter:
         datafeed: Optional[DataFeed[Any]] = None,
         expected_profit: Union[str, float] = 100.0,
         transaction_type: int = 0,
-        gas_limit: int = 350000,
-        max_fee: Optional[int] = None,
-        priority_fee: int = 5,
+        gas_limit: Optional[int] = None,
+        max_fee: int = 0,
+        priority_fee: float = 0.0,
         legacy_gas_price: Optional[int] = None,
-        gas_price_speed: Union[tuple[str], str] = "fast",
+        gas_multiplier: int = 1,
         wait_period: int = 10,
         min_native_token_balance: int = 10**18,
     ) -> None:
@@ -70,11 +72,14 @@ class IntervalReporter:
         self.max_fee = max_fee
         self.priority_fee = priority_fee
         self.legacy_gas_price = legacy_gas_price
-        self.gas_price_speed = [gas_price_speed]
+        self.gas_multiplier = gas_multiplier
         self.trb_usd_median_feed = trb_usd_median_feed
         self.eth_usd_median_feed = eth_usd_median_feed
         self.wait_period = wait_period
         self.min_native_token_balance = min_native_token_balance
+        self.web3 = self.endpoint._web3
+
+        self.gas_info: dict[str, Union[float, int]] = {}
 
         logger.info(f"Reporting with account: {self.acct_addr}")
 
@@ -108,9 +113,24 @@ class IntervalReporter:
 
         return status
 
-    async def fetch_gas_price(self, speed: Optional[Any] = None) -> Optional[int]:
-        """Fetch gas price from ethgasstation in gwei."""
-        return await legacy_gas_station(chain_id=self.chain_id, speed_parse_lis=speed)  # type: ignore
+    async def fetch_gas_price(self) -> Optional[float]:
+        """Fetches the current gas price from the Ethereum network and returns
+        an adjusted gas price.
+
+        Returns:
+            An optional integer representing the adjusted gas price in wei, or
+            None if the gas price could not be retrieved.
+        """
+        try:
+            price = self.web3.eth.gas_price
+            priceGwei = self.web3.fromWei(price, "gwei")
+        except Exception as e:
+            logger.error(f"Error fetching gas price: {e}")
+            return None
+        # increase gas price by 1.0 + gas_multiplier
+        multiplier = 1.0 + (self.gas_multiplier / 100.0)
+        gas_price = (float(priceGwei) * multiplier) if priceGwei else None
+        return gas_price
 
     async def ensure_staked(self) -> Tuple[bool, ResponseStatus]:
         """Make sure the current user is staked
@@ -168,10 +188,7 @@ class IntervalReporter:
             msg = "Current address is locked in dispute or for withdrawal."  # noqa: E501
             return False, error_status(msg, log=logger.info)
 
-    async def ensure_profitable(
-        self,
-        datafeed: DataFeed[Any],
-    ) -> ResponseStatus:
+    async def ensure_profitable(self, datafeed: DataFeed[Any]) -> ResponseStatus:
         """Estimate profitability
 
         Returns a bool signifying whether submitting for a given
@@ -205,63 +222,44 @@ class IntervalReporter:
 
         tips, tb_reward = rewards
 
-        # Using transaction type 2 (EIP-1559)
-        if self.transaction_type == 2:
-            fee_info = await self.get_fee_info()
-            base_fee = fee_info[0].suggestBaseFee
+        if not self.gas_info:
+            return error_status("Gas info not set", log=logger.warning)
 
-            # No miner tip provided by user
-            if self.priority_fee is None:
-                # From etherscan docs:
-                # "Safe/Proposed/Fast gas price recommendations are now modeled as Priority Fees."  # noqa: E501
-                # Source: https://docs.etherscan.io/api-endpoints/gas-tracker
-                priority_fee = fee_info[0].SafeGasPrice
-                self.priority_fee = priority_fee
+        gas_info = self.gas_info
+        txn_fee = gas_info["gas_price"] * gas_info["gas_limit"]
 
-            if self.max_fee is None:
-                # From Alchemy docs:
-                # "maxFeePerGas = baseFeePerGas + maxPriorityFeePerGas"
-                # Source: https://docs.alchemy.com/alchemy/guides/eip-1559/maxpriorityfeepergas-vs-maxfeepergas  # noqa: E501
-                self.max_fee = self.priority_fee + base_fee
-
+        if gas_info["type"] == 0:
+            txn_fee = gas_info["gas_price"] * gas_info["gas_limit"]
             logger.info(
                 f"""
-                tips: {tips / 1e18} TRB
-                time-based reward: {tb_reward / 1e18} TRB
-                gas limit: {self.gas_limit}
-                base fee: {base_fee}
-                priority fee: {self.priority_fee}
-                max fee: {self.max_fee}
+
+                Tips: {tips / 1e18}
+                Time-based reward: {tb_reward / 1e18} TRB
+                Transaction fee: {self.web3.fromWei(txn_fee, 'gwei'):.09f} {tkn_symbol(self.chain_id)}
+                Gas price: {gas_info["gas_price"]} gwei
+                Gas limit: {gas_info["gas_limit"]}
+                Txn type: 0 (Legacy)
                 """
             )
-
-            costs = self.gas_limit * self.max_fee
-
-        # Using transaction type 0 (legacy)
-        else:
-            # Fetch legacy gas price if not provided by user
-            if not self.legacy_gas_price:
-                gas_price = await self.fetch_gas_price(speed=self.gas_price_speed)
-                self.legacy_gas_price = gas_price
-
-            if not self.legacy_gas_price:
-                note = "Unable to fetch gas price for tx type 0"
-                return error_status(note, log=logger.warning)
-
+        if gas_info["type"] == 2:
+            txn_fee = gas_info["max_fee"] * gas_info["gas_limit"]
             logger.info(
                 f"""
-                tips: {tips / 1e18} TRB
-                time-based reward: {tb_reward / 1e18} TRB
-                gas limit: {self.gas_limit}
-                legacy gas price: {self.legacy_gas_price}
+
+                Tips: {tips / 1e18}
+                Time-based reward: {tb_reward / 1e18} TRB
+                Max transaction fee: {self.web3.fromWei(txn_fee, 'gwei')} {tkn_symbol(self.chain_id)}
+                Max fee per gas: {gas_info["max_fee"]} gwei
+                Max priority fee per gas: {gas_info["priority_fee"]} gwei
+                Gas limit: {gas_info["gas_limit"]}
+                Txn type: 2 (EIP-1559)
                 """
             )
-            costs = self.gas_limit * self.legacy_gas_price
 
         # Calculate profit
         revenue = tb_reward + tips
         rev_usd = revenue / 1e18 * price_trb_usd
-        costs_usd = costs / 1e9 * price_eth_usd
+        costs_usd = txn_fee / 1e9 * price_eth_usd
         profit_usd = rev_usd - costs_usd
         logger.info(f"Estimated profit: ${round(profit_usd, 2)}")
 
@@ -276,7 +274,7 @@ class IntervalReporter:
 
         return status
 
-    async def get_fee_info(self) -> Any:
+    async def get_fee_info(self) -> OptionalDataPoint[EtherscanGasPrice]:
         """Fetch fee into from Etherscan API.
         Source: https://etherscan.io/apis"""
         c = EtherscanGasPriceSource()
@@ -301,16 +299,35 @@ class IntervalReporter:
         return await is_online()
 
     def has_native_token(self) -> bool:
-        return has_native_token_funds(self.acct_addr, self.endpoint._web3, min_balance=self.min_native_token_balance)
+        """Check if account has native token funds for a network for gas fees
+        of at least min_native_token_balance that is set in the cli"""
+        return has_native_token_funds(self.acct_addr, self.web3, min_balance=self.min_native_token_balance)
 
     def get_acct_nonce(self) -> tuple[Optional[int], ResponseStatus]:
         """Get transaction count for an address"""
         try:
-            return self.endpoint._web3.eth.get_transaction_count(self.acct_addr), ResponseStatus()
+            return self.web3.eth.get_transaction_count(self.acct_addr), ResponseStatus()
         except ValueError as e:
             return None, error_status("Account nonce request timed out", e=e, log=logger.warning)
         except Exception as e:
             return None, error_status("Unable to retrieve account nonce", e=e, log=logger.error)
+
+    # Estimate gas usage and set the gas limit if not provided
+    def submit_val_tx_gas_limit(self, submit_val_tx: ContractFunction) -> tuple[Optional[int], ResponseStatus]:
+        """Estimate gas usage for submitValue transaction
+        Args:
+            submit_val_tx: The submitValue transaction object
+        Returns a tuple of the gas limit and a ResponseStatus object"""
+        if self.gas_limit is None:
+            try:
+                gas_limit: int = submit_val_tx.estimateGas({"from": self.acct_addr})
+                if not gas_limit:
+                    return None, error_status("Unable to estimate gas for submitValue transaction")
+                return gas_limit, ResponseStatus()
+            except Exception as e:
+                msg = "Unable to estimate gas for submitValue transaction"
+                return None, error_status(msg, e=e, log=logger.error)
+        return self.gas_limit, ResponseStatus()
 
     async def report_once(
         self,
@@ -337,12 +354,6 @@ class IntervalReporter:
             return None, error_status(note=msg, log=logger.info)
 
         logger.info(f"Current query: {datafeed.query.descriptor}")
-
-        status = await self.ensure_profitable(datafeed)
-        if not status.ok:
-            return None, status
-
-        status = ResponseStatus()
 
         # Update datafeed value
         await datafeed.source.fetch_new_datapoint()
@@ -379,24 +390,44 @@ class IntervalReporter:
             _nonce=report_count,
             _queryData=query_data,
         )
+        # Estimate gas usage amount
+        gas_limit, status = self.submit_val_tx_gas_limit(submit_val_tx=submit_val_tx)
+        if not status.ok or gas_limit is None:
+            return None, status
+
+        self.gas_info["gas_limit"] = gas_limit
+        # Get account nonce
         acc_nonce, nonce_status = self.get_acct_nonce()
         if not nonce_status.ok:
             return None, nonce_status
-
         # Add transaction type 2 (EIP-1559) data
         if self.transaction_type == 2:
-            logger.info(f"maxFeePerGas: {self.max_fee}")
-            logger.info(f"maxPriorityFeePerGas: {self.priority_fee}")
+            if not self.max_fee:
+                fee_info = await self.get_fee_info()
+                if fee_info[0] is None:
+                    return None, error_status("Unable to suggest type 2 txn fees", log=logger.error)
+                base_fee = fee_info[0].suggestBaseFee
+                priority_fee = fee_info[0].SafeGasPrice if not self.priority_fee else self.priority_fee
+                max_fee = int(priority_fee + base_fee)
+            else:
+                max_fee = self.max_fee
+                priority_fee = self.priority_fee
+
+            # Set gas price to max fee used for profitability check
+            self.gas_info["type"] = 2
+            self.gas_info["max_fee"] = max_fee
+            self.gas_info["priority_fee"] = priority_fee
+            self.gas_info["base_fee"] = max_fee - priority_fee
 
             built_submit_val_tx = submit_val_tx.buildTransaction(
                 {
                     "nonce": acc_nonce,
-                    "gas": self.gas_limit,
-                    "maxFeePerGas": Web3.toWei(self.max_fee, "gwei"),  # type: ignore
+                    "gas": gas_limit,
+                    "maxFeePerGas": self.web3.toWei(max_fee, "gwei"),
                     # TODO: Investigate more why etherscan txs using Flashbots have
                     # the same maxFeePerGas and maxPriorityFeePerGas. Example:
                     # https://etherscan.io/tx/0x0bd2c8b986be4f183c0a2667ef48ab1d8863c59510f3226ef056e46658541288 # noqa: E501
-                    "maxPriorityFeePerGas": Web3.toWei(self.priority_fee, "gwei"),  # noqa: E501
+                    "maxPriorityFeePerGas": self.web3.toWei(priority_fee, "gwei"),  # noqa: E501
                     "chainId": self.chain_id,
                 }
             )
@@ -404,21 +435,31 @@ class IntervalReporter:
         else:
             # Fetch legacy gas price if not provided by user
             if not self.legacy_gas_price:
-                gas_price = await self.fetch_gas_price(self.gas_price_speed)
+                gas_price = await self.fetch_gas_price()
                 if not gas_price:
                     note = "Unable to fetch gas price for tx type 0"
                     return None, error_status(note, log=logger.warning)
+
             else:
                 gas_price = self.legacy_gas_price
-
+            # Set gas price to legacy gas price used for profitability check
+            self.gas_info["type"] = 0
+            self.gas_info["gas_price"] = gas_price
             built_submit_val_tx = submit_val_tx.buildTransaction(
                 {
                     "nonce": acc_nonce,
-                    "gas": self.gas_limit,
-                    "gasPrice": Web3.toWei(gas_price, "gwei"),
+                    "gas": gas_limit,
+                    "gasPrice": self.web3.toWei(gas_price, "gwei"),
                     "chainId": self.chain_id,
                 }
             )
+
+        # Check if profitable if not YOLO
+        status = await self.ensure_profitable(datafeed)
+        if not status.ok:
+            return None, status
+        # TODO: double check if this is needed
+        status = ResponseStatus()
 
         lazy_unlock_account(self.account)
         local_account = self.account.local_account
@@ -429,14 +470,14 @@ class IntervalReporter:
 
         try:
             logger.debug("Sending submitValue transaction")
-            tx_hash = self.endpoint._web3.eth.send_raw_transaction(tx_signed.rawTransaction)
+            tx_hash = self.web3.eth.send_raw_transaction(tx_signed.rawTransaction)
         except Exception as e:
             note = "Send transaction failed"
             return None, error_status(note, log=logger.error, e=e)
 
         try:
             # Confirm transaction
-            tx_receipt = self.endpoint._web3.eth.wait_for_transaction_receipt(tx_hash, timeout=360)
+            tx_receipt = self.web3.eth.wait_for_transaction_receipt(tx_hash, timeout=360)
 
             tx_url = f"{self.endpoint.explorer}/tx/{tx_hash.hex()}"
 

--- a/src/telliot_feeds/reporters/rng_interval.py
+++ b/src/telliot_feeds/reporters/rng_interval.py
@@ -1,7 +1,6 @@
 """TellorRNG auto submitter.
 submits TellorRNG values at a fixed time interval
 """
-import asyncio
 import calendar
 import time
 from typing import Any
@@ -11,9 +10,7 @@ from telliot_core.utils.response import error_status
 from telliot_core.utils.response import ResponseStatus
 
 from telliot_feeds.datafeed import DataFeed
-from telliot_feeds.feeds.matic_usd_feed import matic_usd_median_feed
 from telliot_feeds.feeds.tellor_rng_feed import assemble_rng_datafeed
-from telliot_feeds.feeds.trb_usd_feed import trb_usd_median_feed
 from telliot_feeds.queries.tellor_rng import TellorRNG
 from telliot_feeds.reporters.reporter_autopay_utils import get_feed_tip
 from telliot_feeds.reporters.tellor_360 import Tellor360Reporter
@@ -79,83 +76,5 @@ class RNGReporter(Tellor360Reporter):
             error_status(msg, log=logger.warning)
             return None
         tip += feed_tip
-
-        # Fetch token prices in USD
-        price_feeds = [matic_usd_median_feed, trb_usd_median_feed]
-        _ = await asyncio.gather(*[feed.source.fetch_new_datapoint() for feed in price_feeds])
-        price_matic_usd = matic_usd_median_feed.source.latest[0]
-        price_trb_usd = trb_usd_median_feed.source.latest[0]
-        if price_matic_usd is None or price_trb_usd is None:
-            msg = "Unable to fetch token prices"
-            error_status(msg, log=logger.warning)
-            return None
-
-        # Using transaction type 2 (EIP-1559)
-        if self.transaction_type == 2:
-            fee_info = await self.get_fee_info()
-            base_fee = fee_info[0].suggestBaseFee
-
-            # No miner tip provided by user
-            if self.priority_fee is None:
-                # From etherscan docs:
-                # "Safe/Proposed/Fast gas price recommendations are now modeled as Priority Fees."  # noqa: E501
-                # Source: https://docs.etherscan.io/api-endpoints/gas-tracker
-                priority_fee = fee_info[0].SafeGasPrice
-                self.priority_fee = priority_fee
-
-            if self.max_fee is None:
-                # From Alchemy docs:
-                # "maxFeePerGas = baseFeePerGas + maxPriorityFeePerGas"
-                # Source: https://docs.alchemy.com/alchemy/guides/eip-1559/maxpriorityfeepergas-vs-maxfeepergas  # noqa: E501
-                self.max_fee = self.priority_fee + base_fee
-
-            logger.info(
-                f"""
-                tips: {tip} TRB
-                gas limit: {self.gas_limit}
-                base fee: {base_fee}
-                priority fee: {self.priority_fee}
-                max fee: {self.max_fee}
-                """
-            )
-
-            costs = self.gas_limit * self.max_fee
-
-        # Using transaction type 0 (legacy)
-        else:
-            # Fetch legacy gas price if not provided by user
-            if not self.legacy_gas_price:
-                gas_price = await self.fetch_gas_price()
-                self.legacy_gas_price = gas_price
-
-            if not self.legacy_gas_price:
-                note = "unable to fetch gas price from api"
-                error_status(note, log=logger.info)
-                return None
-            logger.info(
-                f"""
-                tips: {tip/1e18} TRB
-                gas limit: {self.gas_limit}
-                legacy gas price: {self.legacy_gas_price}
-                """
-            )
-            costs = self.gas_limit * self.legacy_gas_price
-
-        # Calculate profit
-        rev_usd = tip / 1e18 * price_trb_usd
-        costs_usd = costs / 1e9 * price_matic_usd
-        profit_usd = rev_usd - costs_usd
-        logger.info(f"Estimated profit: ${round(profit_usd, 2)}")
-        logger.info(f"tip price: {round(rev_usd, 2)}, gas costs: {costs_usd}")
-
-        percent_profit = ((profit_usd) / costs_usd) * 100
-        logger.info(f"Estimated percent profit: {round(percent_profit, 2)}%")
-        if (self.expected_profit != "YOLO") and (
-            isinstance(self.expected_profit, float) and percent_profit < self.expected_profit
-        ):
-            status.ok = False
-            status.error = "Estimated profitability below threshold."
-            logger.info(status.error)
-            return None
-
+        logger.debug(f"Current tip for RNG query: {tip}")
         return datafeed

--- a/src/telliot_feeds/reporters/tellor_360.py
+++ b/src/telliot_feeds/reporters/tellor_360.py
@@ -144,17 +144,9 @@ class Tellor360Reporter(TellorFlexReporter):
                 return False, error_status(msg, log=logger.warning)
             # approve token spending
             if self.transaction_type == 2:
-                # see comments of how fee is structured in TellorFlexReporter
-                if not self.max_fee:
-                    fee_info = await self.get_fee_info()
-                    if fee_info[0] is None:
-                        return False, error_status("Unable to suggest type 2 txn fees", log=logger.error)
-                    base_fee = fee_info[0].suggestBaseFee
-                    priority_fee = fee_info[0].SafeGasPrice if not self.priority_fee else self.priority_fee
-                    max_fee = int(priority_fee + base_fee)
-                else:
-                    max_fee = self.max_fee
-                    priority_fee = self.priority_fee
+                priority_fee, max_fee = self.get_fee_info()
+                if priority_fee is None or max_fee is None:
+                    return False, error_status("Unable to suggest type 2 txn fees", log=logger.error)
                 # Approve token spending for a transaction type 2
                 receipt, approve_status = await self.token.write(
                     func_name="approve",

--- a/src/telliot_feeds/reporters/tellor_360.py
+++ b/src/telliot_feeds/reporters/tellor_360.py
@@ -190,7 +190,6 @@ class Tellor360Reporter(TellorFlexReporter):
                 else:
                     gas_price_in_gwei = self.legacy_gas_price
                 # Approve token spending for a transaction type 0 and deposit stake
-                # Approve token spending
                 receipt, approve_status = await self.token.write(
                     func_name="approve",
                     gas_limit=self.gas_limit,

--- a/src/telliot_feeds/reporters/tellor_flex.py
+++ b/src/telliot_feeds/reporters/tellor_flex.py
@@ -304,7 +304,7 @@ class TellorFlexReporter(IntervalReporter):
                 f"""
 
                 Tips: {tip/1e18}
-                Max transaction fee: {self.web3.fromWei(txn_fee, 'gwei')} {tkn_symbol(self.chain_id)}
+                Max transaction fee: {self.web3.fromWei(txn_fee, 'gwei'):.18f} {tkn_symbol(self.chain_id)}
                 Max fee per gas: {gas_info["max_fee"]} gwei
                 Max priority fee per gas: {gas_info["priority_fee"]} gwei
                 Gas limit: {gas_info["gas_limit"]}

--- a/src/telliot_feeds/reporters/tips/__init__.py
+++ b/src/telliot_feeds/reporters/tips/__init__.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Optional
 
 from multicall.constants import MULTICALL2_ADDRESSES
@@ -6,9 +7,8 @@ from multicall.constants import Network
 from multicall.constants import NO_STATE_OVERRIDE
 
 from telliot_feeds.queries.query_catalog import query_catalog
-from telliot_feeds.utils.log import get_logger
 
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 # add testnet support for multicall that aren't avaialable in the package
@@ -33,7 +33,7 @@ def add_multicall_support(
         else:
             MULTICALL3_ADDRESSES[attr] = multicall3_address
     else:
-        logger.warning(f"Network {network} already exists in multicall package")
+        print(f"Network {network} already exists in multicall package")
 
 
 add_multicall_support(

--- a/src/telliot_feeds/utils/reporter_utils.py
+++ b/src/telliot_feeds/utils/reporter_utils.py
@@ -168,3 +168,12 @@ def get_native_token_feed(chain_id: int) -> DataFeed[float]:
         return xdai_usd_median_feed
     else:
         raise ValueError(f"Cannot fetch native token feed. Invalid chain ID: {chain_id}")
+
+
+def tkn_symbol(chain_id: int) -> str:
+    if chain_id in POLYGON_CHAINS:
+        return "MATIC"
+    elif chain_id in GNOSIS_CHAINS:
+        return "XDAI"
+    else:
+        return "ETH"

--- a/src/telliot_feeds/utils/reporter_utils.py
+++ b/src/telliot_feeds/utils/reporter_utils.py
@@ -175,5 +175,7 @@ def tkn_symbol(chain_id: int) -> str:
         return "MATIC"
     elif chain_id in GNOSIS_CHAINS:
         return "XDAI"
-    else:
+    elif chain_id in ETHEREUM_CHAINS:
         return "ETH"
+    else:
+        return "Unknown native token"

--- a/tests/reporters/test_interval_reporter.py
+++ b/tests/reporters/test_interval_reporter.py
@@ -30,9 +30,10 @@ async def test_fetch_datafeed(tellor_flex_reporter):
     assert isinstance(feed, DataFeed)
 
 
+@pytest.mark.skip(reason="EIP-1559 not supported by ganache")
 @pytest.mark.asyncio
-async def test_get_fee_info(tellor_flex_reporter):
-    info, time = await tellor_flex_reporter.get_fee_info()
+def test_get_fee_info(tellor_flex_reporter):
+    info, time = tellor_flex_reporter.get_fee_info()
 
     assert isinstance(time, datetime)
     assert isinstance(info, EtherscanGasPrice)

--- a/tests/reporters/test_interval_reporter.py
+++ b/tests/reporters/test_interval_reporter.py
@@ -12,7 +12,6 @@ from web3.datastructures import AttributeDict
 
 from telliot_feeds.datafeed import DataFeed
 from telliot_feeds.feeds.eth_usd_feed import eth_usd_median_feed
-from telliot_feeds.reporters import interval
 from telliot_feeds.sources.etherscan_gas import EtherscanGasPrice
 from tests.utils.utils import gas_price
 from tests.utils.utils import passing_bool_w_status
@@ -68,6 +67,7 @@ async def test_ensure_staked(tellor_flex_reporter):
 async def test_ensure_profitable(tellor_flex_reporter):
     """Test profitability check."""
     r = tellor_flex_reporter
+    r.gas_info = {"type": 0, "gas_price": 1e9, "gas_limit": 300000}
 
     assert r.expected_profit == "YOLO"
 
@@ -84,16 +84,14 @@ async def test_ensure_profitable(tellor_flex_reporter):
 
 @pytest.mark.asyncio
 async def test_ethgasstation_error(tellor_flex_reporter):
-    async def no_gas_price(*args, **kwargs):
-        return None
+    with mock.patch("telliot_feeds.reporters.interval.IntervalReporter.fetch_gas_price") as func:
+        func.return_value = None
+        r = tellor_flex_reporter
+        r.stake = 1000000 * 10**18
 
-    r = tellor_flex_reporter
-    r.stake = 1000000 * 10**18
-    interval.ethgasstation = no_gas_price
-
-    staked, status = await r.ensure_staked()
-    assert not staked
-    assert not status.ok
+        staked, status = await r.ensure_staked()
+        assert not staked
+        assert not status.ok
 
 
 @pytest.mark.asyncio
@@ -210,6 +208,7 @@ async def test_ensure_reporter_lock_check_after_submitval_attempt(tellor_flex_re
     r.ensure_profitable = passing_status
     r.check_reporter_lock = passing_status
     r.datafeed = eth_usd_median_feed
+    r.gas_limit = 350000
 
     # Simulate fetching latest value
     r.datafeed.source.sources = [guaranteed_price_source]


### PR DESCRIPTION
<!-- Make sure that your title neatly summarizes the proposed changes -->

### Summary
Closes #602 
Closes [#362](https://github.com/tellor-io/telliot-core/issues/362)
Closes [#355](https://github.com/tellor-io/telliot-core/issues/355)
Closes [#367](https://github.com/tellor-io/telliot-core/issues/367)
1. in command/report.py:
- removed speed flag used for gas api endpoint responses.
- add gas multiplier to up the gas price returned by web3 (optional)
2. in reporters/interval.py:
- change fetch_gas_price function to fetch gas price from web3 api instead of other apis' and returns a float to maintain the decimals especially when the number is close to zero.  The returned number is increased by the multiplier (default increase by 1 percent)
- switched flow between ensure_profitability and gas calculations to instead build transaction function, get gas price, then call ensure_profitability which checks if there is profit based on the carried over gas price and gas limit and the rest of the other calculations ie token prices.
3. in reporters/rng_interval.py:
- remove the profit calculations from the file since thats already in the parent class.  It looks like it was there because native tokens weren't checked for profitability but now they are.
4. in reporters/tellorflex.py:
- removed the method since its no different than the parent class
- adapted the changes for ensure_profitability.
5. in utils/reporter_utils.py: 
- added function tkn_symbol that returns native token symbol for viewing in the cli when seeing cost info
7. in tests/reporters/test_flex_reporter and test_interval_reporter:
- changes to some tests that add the gas_info attribute
### Steps Taken to QA Changes
<!-- Describe the steps that you have taken to make sure that your changes work as intended without breaking other functionality. These steps should be reproducible and easy to follow for other QA testers-->
Ran all the tests/ and they all pass. (some tests need to be ran individually to pass)
transactions executed with these flags: -qt eth-usd-spot -p YOLO
[Flashbot txn](https://goerli.beaconcha.in/tx/6d1c2405a243e0acdce2876c2eb8834d741be29327126e130b2a995d2a22c4bb)
[goerli](https://goerli.etherscan.io/tx/0xd84666d7c93f6896f34cb0b618f4a2359edc339dc74ad5fea07a8f25a3ee3279)
[arbitrum](https://goerli.arbiscan.io//tx/0x21e2ff372414d6fa96fd80485b17230d6c444072831cb72f83dc32441cb0264e)
[optimism](https://goerli-optimism.etherscan.io//tx/0x9818e0466ab99a9d14523f73fdf335a16a564851cf2e023cab59288c32df8427)
[mumbai](https://mumbai.polygonscan.com//tx/0x2ac8edc5684f8b7cd21a939ce043b69338314d01c122d47b66b8b26ec66b8e61)

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)
-->

This pull request is:

- [ ] A documentation error, docs update, or typographical error fix
	- No tests or issue needed
- [ ] A code fix
	- Please reference the related issue by including "Closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a bug report issue 
	- Please include tests. Fixes without tests will not be accepted unless it's related to the documentation only.
    - Please make sure docs are updated if need be
- [x] A feature implementation
	- Please reference the related issue by including "Closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a feature enhancement issue 
	- Please include tests
    - Please make sure docs updates are both thorough and easy to reproduce by somebody with limited knowledge of the feature that you are submitting


**Happy engineering!**