### PR TITLE
Fix bug in RNG causing same value to be reported

### DIFF
--- a/src/telliot_feeds/cli/commands/report.py
+++ b/src/telliot_feeds/cli/commands/report.py
@@ -369,7 +369,7 @@ async def report(
                 return
             chosen_feed = None
         elif rng_timestamp is not None:
-            chosen_feed = await assemble_rng_datafeed(timestamp=rng_timestamp, node=core.endpoint, account=account)
+            chosen_feed = await assemble_rng_datafeed(timestamp=rng_timestamp)
         else:
             chosen_feed = None
 

--- a/src/telliot_feeds/feeds/tellor_rng_feed.py
+++ b/src/telliot_feeds/feeds/tellor_rng_feed.py
@@ -1,9 +1,6 @@
 """Datafeed for pseudorandom number from hashing multiple blockhashes together."""
 from typing import Optional
 
-import chained_accounts
-from telliot_core.model.endpoints import RPCEndpoint
-
 from telliot_feeds.datafeed import DataFeed
 from telliot_feeds.queries.tellor_rng import TellorRNG
 from telliot_feeds.sources.blockhash_aggregator import TellorRNGManualSource
@@ -13,11 +10,10 @@ local_source = TellorRNGManualSource()
 tellor_rng_feed = DataFeed(source=local_source, query=TellorRNG(timestamp=local_source.timestamp))
 
 
-async def assemble_rng_datafeed(
-    timestamp: int, node: RPCEndpoint, account: chained_accounts
-) -> Optional[DataFeed[float]]:
+async def assemble_rng_datafeed(timestamp: int) -> Optional[DataFeed[float]]:
     """Assembles a TellorRNG datafeed for the given timestamp."""
-    local_source.set_timestamp(timestamp)
-    feed = DataFeed(source=local_source, query=TellorRNG(timestamp=timestamp))
+    source = TellorRNGManualSource()
+    source.set_timestamp(timestamp)
+    feed = DataFeed(source=source, query=TellorRNG(timestamp=timestamp))
 
     return feed

--- a/src/telliot_feeds/reporters/rng_interval.py
+++ b/src/telliot_feeds/reporters/rng_interval.py
@@ -53,7 +53,7 @@ class RNGReporter(Tellor360Reporter):
             logger.info(status.error)
             return None
 
-        datafeed = await assemble_rng_datafeed(timestamp=rng_timestamp, node=self.endpoint, account=self.account)
+        datafeed = await assemble_rng_datafeed(timestamp=rng_timestamp)
         if datafeed is None:
             msg = "Unable to assemble RNG datafeed"
             error_status(note=msg, log=logger.warning)

--- a/tests/reporters/test_rng_reporter.py
+++ b/tests/reporters/test_rng_reporter.py
@@ -7,6 +7,8 @@ from telliot_core.apps.core import TelliotCore
 from telliot_core.utils.response import ResponseStatus
 from web3.datastructures import AttributeDict
 
+from telliot_feeds.datafeed import DataFeed
+from telliot_feeds.queries.tellor_rng import TellorRNG
 from telliot_feeds.reporters.rng_interval import logger
 from telliot_feeds.reporters.rng_interval import RNGReporter
 
@@ -15,6 +17,10 @@ from telliot_feeds.reporters.rng_interval import RNGReporter
 def mock_zero_timestamp():
     """Mock get_next_timestamp to return 0."""
     return 0
+
+
+async def mock_response_status(*args, **kwargs):
+    return ResponseStatus()
 
 
 @pytest_asyncio.fixture(scope="function")
@@ -97,15 +103,9 @@ async def test_missing_blockhash(rng_reporter, monkeypatch, caplog):
 
     r.is_online = mock_online
 
-    async def mock_check_reporter_lock(*args, **kwargs):
-        return ResponseStatus()
+    r.check_reporter_lock = mock_response_status
 
-    r.check_reporter_lock = mock_check_reporter_lock
-
-    async def mock_ensure_profitable(*args, **kwargs):
-        return ResponseStatus()
-
-    r.ensure_profitable = mock_ensure_profitable
+    r.ensure_profitable = mock_response_status
 
     await r.report(report_count=3)
 
@@ -145,3 +145,63 @@ async def test_invalid_timestamp_in_future(rng_reporter, monkeypatch, caplog):
         assert status.ok
         assert receipt["status"] == 1
         assert "less than current time" in caplog.text
+
+
+def generate_numbers():
+    current_number = 1678311000
+    while current_number > 1678310000:
+        yield current_number
+        current_number = int(time.time())
+
+
+@pytest.mark.asyncio
+async def test_repeat_auto_rng_report_value(rng_reporter: RNGReporter, monkeypatch, caplog):
+    """Test that shows the bad behavior before bug fix that was causing same value
+    to be reported for timestamps that didn't have block hashes generated yet.
+    Reason is global scope of local_source variable in assemble_rng_datafeed function
+    """
+    # function before fix was applied used local_source var from global scope
+    from telliot_feeds.feeds.tellor_rng_feed import local_source
+
+    async def assemble_feed(timestamp):
+        local_source.set_timestamp(timestamp)
+        return DataFeed(source=local_source, query=TellorRNG(timestamp=timestamp))
+
+    rng_reporter.wait_period = 0
+    num = generate_numbers()
+    # test to show difference before fix
+    with monkeypatch.context() as m:
+        m.setattr("telliot_feeds.reporters.rng_interval.assemble_rng_datafeed", assemble_feed)
+        m.setattr("telliot_feeds.reporters.rng_interval.get_next_timestamp", lambda: next(num))
+        m.setattr(
+            "telliot_feeds.reporters.rng_interval.RNGReporter.check_reporter_lock",
+            mock_response_status,
+        )
+        # first report uses timestamp that has block hashes avaialble to generate rng
+        # second timestamp does not have block hashes yet because it is current
+        await rng_reporter.report(2)
+        # encoded value for timestamp 1678311000
+        count = caplog.text.count(
+            "IntervalReporter Encoded value: 236eabcc1c1dc5c01bd6357576b17e490eaf7aaa37b360485cddcd6877a395c3"
+        )
+        # count is 2 because second report uses same value
+        assert count == 2
+
+
+@pytest.mark.asyncio
+async def test_unique_rng_report_value(rng_reporter: RNGReporter, monkeypatch, caplog):
+    """Test that rng report value isn't submitting the same value twice."""
+    rng_reporter.wait_period = 0
+    num = generate_numbers()
+
+    with monkeypatch.context() as m:
+        m.setattr("telliot_feeds.reporters.rng_interval.get_next_timestamp", lambda: next(num))
+        m.setattr(
+            "telliot_feeds.reporters.rng_interval.RNGReporter.check_reporter_lock",
+            mock_response_status,
+        )
+        await rng_reporter.report(2)
+        count = caplog.text.count(
+            "IntervalReporter Encoded value: 236eabcc1c1dc5c01bd6357576b17e490eaf7aaa37b360485cddcd6877a395c3"
+        )
+        assert count == 1


### PR DESCRIPTION
<!-- Make sure that your title neatly summarizes the proposed changes -->

### Summary
<!-- Provide a short overview of the change and the value it adds -->
- Closes #614
- Fix bug that was causing RNG reporter to report same value multiple times for different query ids when following a successful report followed by a timestamp that didn't have a current block hash even though the query id was different.
- I think it was a scoping issue, the function that returns a datafeed was using a global source variable.
### Steps Taken to QA Changes
<!-- Describe the steps that you have taken to make sure that your changes work as intended without breaking other functionality. These steps should be reproducible and easy to follow for other QA testers-->
- Added a test to show the effects before the fix
- Another test to show the effects after the fix
- Currently reporting to make sure the fix was sufficient

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)
-->

This pull request is:

- [ ] A documentation error, docs update, or typographical error fix
	- No tests or issue needed
- [x] A code fix
	- Please reference the related issue by including "Closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a bug report issue 
	- Please include tests. Fixes without tests will not be accepted unless it's related to the documentation only.
    - Please make sure docs are updated if need be
- [ ] A feature implementation
	- Please reference the related issue by including "Closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a feature enhancement issue 
	- Please include tests
    - Please make sure docs updates are both thorough and easy to reproduce by somebody with limited knowledge of the feature that you are submitting


**Happy engineering!**