### PR TITLE
OP/USD spot price feed added

### DIFF
--- a/src/telliot_feeds/feeds/__init__.py
+++ b/src/telliot_feeds/feeds/__init__.py
@@ -44,6 +44,7 @@ from telliot_feeds.feeds.mkr_usd_feed import mkr_usd_median_feed
 from telliot_feeds.feeds.numeric_api_response_feed import numeric_api_response_feed
 from telliot_feeds.feeds.numeric_api_response_manual_feed import numeric_api_response_manual_feed
 from telliot_feeds.feeds.olympus import ohm_eth_median_feed
+from telliot_feeds.feeds.op_usd_feed import op_usd_median_feed
 from telliot_feeds.feeds.pls_usd_feed import pls_usd_feed
 from telliot_feeds.feeds.rai_usd_feed import rai_usd_median_feed
 from telliot_feeds.feeds.reth_btc_feed import reth_btc_median_feed
@@ -130,6 +131,7 @@ CATALOG_FEEDS = {
     "reth-btc-spot": reth_btc_median_feed,
     "reth-usd-spot": reth_usd_median_feed,
     "wsteth-usd-spot": wsteth_usd_median_feed,
+    "op-usd-spot": op_usd_median_feed,
 }
 
 DATAFEED_BUILDER_MAPPING: Dict[str, DataFeed[Any]] = {

--- a/src/telliot_feeds/feeds/op_usd_feed.py
+++ b/src/telliot_feeds/feeds/op_usd_feed.py
@@ -1,0 +1,18 @@
+from telliot_feeds.datafeed import DataFeed
+from telliot_feeds.queries.price.spot_price import SpotPrice
+from telliot_feeds.sources.price.spot.coinbase import CoinbaseSpotPriceSource
+from telliot_feeds.sources.price.spot.coingecko import CoinGeckoSpotPriceSource
+from telliot_feeds.sources.price_aggregator import PriceAggregator
+
+op_usd_median_feed = DataFeed(
+    query=SpotPrice(asset="OP", currency="USD"),
+    source=PriceAggregator(
+        asset="op",
+        currency="usd",
+        algorithm="median",
+        sources=[
+            CoinGeckoSpotPriceSource(asset="op", currency="usd"),
+            CoinbaseSpotPriceSource(asset="op", currency="usd"),
+        ],
+    ),
+)

--- a/src/telliot_feeds/queries/price/spot_price.py
+++ b/src/telliot_feeds/queries/price/spot_price.py
@@ -58,6 +58,7 @@ SPOT_PRICE_PAIRS = [
     "RETH/BTC",
     "RETH/USD",
     "WSTETH/USD",
+    "OP/USD",
 ]
 
 

--- a/src/telliot_feeds/queries/query_catalog.py
+++ b/src/telliot_feeds/queries/query_catalog.py
@@ -349,3 +349,9 @@ query_catalog.add_entry(
     title="WSTETH/USD spot price",
     q=SpotPrice(asset="wsteth", currency="usd"),
 )
+
+query_catalog.add_entry(
+    tag="op-usd-spot",
+    title="OP/USD spot price",
+    q=SpotPrice(asset="op", currency="usd"),
+)

--- a/src/telliot_feeds/sources/price/spot/coingecko.py
+++ b/src/telliot_feeds/sources/price/spot/coingecko.py
@@ -51,6 +51,7 @@ coingecko_coin_id = {
     "yfi": "yearn-finance",
     "steth": "staked-ether",
     "reth": "rocket-pool-eth",
+    "op": "optimism",
 }
 
 


### PR DESCRIPTION
Made changes to allow for reporting OP/USD. 
tested on-chain with goerli: https://goerli.etherscan.io/tx/0xc01812200cd65858c66761a6d6621b43abad96a700cfa4afb357f22a43aa2299
Please, Let me know if there are any questions or issues.