### PR TITLE
Evm call source with optional blocknumber input

### DIFF
--- a/src/telliot_feeds/sources/evm_call.py
+++ b/src/telliot_feeds/sources/evm_call.py
@@ -3,6 +3,7 @@ from typing import Any
 from typing import Optional
 from typing import Tuple
 
+import web3
 from hexbytes import HexBytes
 from telliot_core.apps.telliot_config import TelliotConfig
 from web3 import middleware
@@ -65,13 +66,13 @@ class EVMCallSource(DataSource[Any]):
         empty_bytes = HexBytes(bytes(32))
 
         try:
-            self.web3.eth.get_block("latest")
-        except Exception:
-            logger.info("EVMCall to POA chain detected. Injecting POA middleware...")
+            self.web3.eth.get_block(block_number)
+        except web3.exceptions.ExtraDataLengthError as e:
+            logger.info(f"EVMCall to POA chain detected. Injecting POA middleware in response to exception: {e}")
 
             try:
                 self.web3.middleware_onion.inject(middleware.geth_poa_middleware, layer=0)
-            except Exception as e:
+            except ValueError as e:
                 logger.warning(f"Unable to inject web3 middleware for POA chain connection: {e}")
 
         try:

--- a/src/telliot_feeds/sources/evm_call.py
+++ b/src/telliot_feeds/sources/evm_call.py
@@ -65,11 +65,11 @@ class EVMCallSource(DataSource[Any]):
         try:
             block_number = self.web3.eth.get_block_number()
             block = self.web3.eth.get_block(block_number)
-            ts = block['timestamp']
+            ts = block["timestamp"]
         except Exception as e:
-            logger.warning(f"Unable to retrieve current block timestamp")
+            logger.warning(f"Unable to retrieve current block timestamp: {e}")
             return None
-        
+
         self.contractAddress = self.web3.toChecksumAddress(self.contractAddress)
 
         if len(self.calldata) < 4:  # A function selector is 4 bytes long, so calldata must be at least of length 4

--- a/src/telliot_feeds/sources/evm_call.py
+++ b/src/telliot_feeds/sources/evm_call.py
@@ -1,13 +1,14 @@
 from dataclasses import dataclass
-from typing import Any, Tuple
+from typing import Any
 from typing import Optional
-from typing import Union
-from web3 import middleware
+from typing import Tuple
+
 from hexbytes import HexBytes
 from telliot_core.apps.telliot_config import TelliotConfig
+from web3 import middleware
 from web3 import Web3
-from web3.types import BlockIdentifier
 from web3.exceptions import ContractLogicError
+from web3.types import BlockIdentifier
 
 from telliot_feeds.datasource import DataSource
 from telliot_feeds.dtypes.datapoint import datetime_now_utc
@@ -64,9 +65,9 @@ class EVMCallSource(DataSource[Any]):
         empty_bytes = HexBytes(bytes(32))
 
         try:
-            self.web3.eth.get_block('latest')
-        except Exception as e:
-            logger.info(f"EVMCall to POA chain detected. Injecting POA middleware...")
+            self.web3.eth.get_block("latest")
+        except Exception:
+            logger.info("EVMCall to POA chain detected. Injecting POA middleware...")
 
             try:
                 self.web3.middleware_onion.inject(middleware.geth_poa_middleware, layer=0)
@@ -86,7 +87,9 @@ class EVMCallSource(DataSource[Any]):
             logger.info(f"Invalid calldata: {self.calldata!r}, too short, submitting empty bytes")
             return (empty_bytes, ts)
         try:
-            result = self.web3.eth.call({"gasPrice": 0, "to": self.contractAddress, "data": self.calldata}, block_number)
+            result = self.web3.eth.call(
+                {"gasPrice": 0, "to": self.contractAddress, "data": self.calldata}, block_number
+            )
         # Is there a scenario where a contract call for a view/pure function would revert when the callData is valid?
         except ContractLogicError as e:
             bytecode = self.web3.eth.getCode(self.contractAddress)

--- a/tests/sources/test_evm_call_source.py
+++ b/tests/sources/test_evm_call_source.py
@@ -2,7 +2,6 @@ import pytest
 from eth_abi import decode_single
 from hexbytes import HexBytes
 from telliot_core.apps.telliot_config import TelliotConfig
-from web3 import Web3
 
 from telliot_feeds.reporters.tellor_360 import Tellor360Reporter
 from telliot_feeds.sources.evm_call import EVMCallSource
@@ -125,6 +124,7 @@ async def test_report_for_bad_calldata(tellor_360):
     # call r.ensure_staked to update staker info
     await r.ensure_staked()
     assert r.staker_info.reports_count == 1
+
 
 def test_evm_call_on_previous_block():
     """Test an EVMCall on a block that isn't the latest block"""

--- a/tests/sources/test_evm_call_source.py
+++ b/tests/sources/test_evm_call_source.py
@@ -63,7 +63,7 @@ async def test_non_getter_calldata():
 
     # test get_response
     response = s.get_response()
-    assert response == (None, None)
+    assert response == None
 
     """Test getter calldata"""
     s.calldata = b"\x73\x25\x24\x94"  # calldata for getGovernanceAddress()

--- a/tests/sources/test_evm_call_source.py
+++ b/tests/sources/test_evm_call_source.py
@@ -63,7 +63,7 @@ async def test_non_getter_calldata():
 
     # test get_response
     response = s.get_response()
-    assert response == None
+    assert not response
 
     """Test getter calldata"""
     s.calldata = b"\x73\x25\x24\x94"  # calldata for getGovernanceAddress()

--- a/tests/sources/test_evm_call_source.py
+++ b/tests/sources/test_evm_call_source.py
@@ -139,7 +139,7 @@ def test_evm_call_on_previous_block():
 
     current_value, current_timestamp = s.get_response()
 
-    old_block_number = s.web3.eth.get_block_number() - 128
+    old_block_number = s.web3.eth.get_block_number() - 2000
 
     previous_value, previous_timestamp = s.get_response(old_block_number)
 

--- a/tests/sources/test_evm_call_source.py
+++ b/tests/sources/test_evm_call_source.py
@@ -145,3 +145,22 @@ def test_evm_call_on_previous_block():
 
     assert current_value != previous_value
     assert current_timestamp != previous_timestamp
+
+
+@pytest.mark.asyncio
+async def test_not_injecting_middlware_twice(caplog):
+    """Test that reusing a POA chain does not crash from middleware"""
+
+    s = EVMCallSource()
+    s.chainId = 80001  # a POA chain, so it will raise web3.exceptions.ExtraDataLengthError
+    s.update_web3()
+
+    # We will use `getCurrentValue` on the ETH/USD query id
+    s.calldata = bytes.fromhex("adf1639d83a7f3d48786ac2667503a61e8c415438ed2922eb86a2906e4ee66d9a2ce4992")
+    s.contractAddress = "0xD9157453E2668B2fc45b7A803D3FEF3642430cC0"
+
+    s.get_response()
+    assert "It is quite likely that you are connected to a POA chain." in caplog.text
+
+    s.get_response()
+    assert "Layer already has middleware with identifier: geth_poa_middleware" not in caplog.text


### PR DESCRIPTION
<!-- Make sure that your title neatly summarizes the proposed changes -->

### Summary
Adds block number parameter to `EVMCallSource.fetch_new_datapoint()` and `EVMCallSource.get_response()`, defaulting to `block_number= "latest"`. Some improved typing for the `get_response()` method as well
### Steps Taken to QA Changes
<!-- Describe the steps that you have taken to make sure that your changes work as intended without breaking other functionality. These steps should be reproducible and easy to follow for other QA testers-->

Added test `test_evm_call_on_previous_block` to ensure that calling a contract method at a previous block returns a different value than the same contract call on the current block. This was tested on a very active variable in the Tellor oracle contract: the value of the ETH/USD spot price.

`pytest tests/sources/test_evm_call_source.py`

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)
-->

This pull request is:

- [ ] A documentation error, docs update, or typographical error fix
	- No tests or issue needed
- [ ] A code fix
	- Please reference the related issue by including "Closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a bug report issue 
	- Please include tests. Fixes without tests will not be accepted unless it's related to the documentation only.
    - Please make sure docs are updated if need be
- [x] A feature implementation
	- Please reference the related issue by including "Closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a feature enhancement issue 
	- Please include tests
    - Please make sure docs updates are both thorough and easy to reproduce by somebody with limited knowledge of the feature that you are submitting


**Happy engineering!**