### PR TITLE
Catch TimeoutError in `is_online` reporter utility

### DIFF
--- a/src/telliot_feeds/utils/reporter_utils.py
+++ b/src/telliot_feeds/utils/reporter_utils.py
@@ -77,7 +77,8 @@ async def is_online() -> bool:
     try:
         requests.get("http://1.1.1.1")
         return True
-    except requests.exceptions.ConnectionError:
+    except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as e:
+        logger.error(f"Unable to connect to internet: {repr(e)}")
         return False
 
 


### PR DESCRIPTION
<!-- Make sure that your title neatly summarizes the proposed changes -->

### Summary
<!-- Provide a short overview of the change and the value it adds -->

The function `telliot_feeds.utils.reporter_utils.is_online()` did not handle the `Timeout` type of `requests` exceptions, which is raised sometimes in the Cloudflare DNS request.

I added the `requests.exceptions.Timeout` exception to be caught by the try-catch clause of the `is_online` function.

### Steps Taken to QA Changes
<!-- Describe the steps that you have taken to make sure that your changes work as intended without breaking other functionality. These steps should be reproducible and easy to follow for other QA testers-->

Added a mocking test for both possible exceptions, ensuring the function returns false if it cannot connect to the internet in both cases. I also tested that the log contains a message that `telliot` cannot connect to the internet. It includes the type and message of the exception as well.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)
-->

This pull request is:

- [ ] A documentation error, docs update, or typographical error fix
	- No tests or issue needed
- [x] A code fix
	- Please reference the related issue by including "Closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a bug report issue 
	- Please include tests. Fixes without tests will not be accepted unless it's related to the documentation only.
    - Please make sure docs are updated if need be
- [ ] A feature implementation
	- Please reference the related issue by including "Closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a feature enhancement issue 
	- Please include tests
    - Please make sure docs updates are both thorough and easy to reproduce by somebody with limited knowledge of the feature that you are submitting


**Happy engineering!**