### PR TITLE
add cny-usd feed & fixed eth-jpy feed

### DIFF
--- a/src/telliot_feeds/feeds/__init__.py
+++ b/src/telliot_feeds/feeds/__init__.py
@@ -10,6 +10,7 @@ from telliot_feeds.feeds.badger_usd_feed import badger_usd_median_feed
 from telliot_feeds.feeds.bch_usd_feed import bch_usd_median_feed
 from telliot_feeds.feeds.bct_usd_feed import bct_usd_median_feed
 from telliot_feeds.feeds.btc_usd_feed import btc_usd_median_feed
+from telliot_feeds.feeds.cny_usd_feed import cny_usd_median_feed
 from telliot_feeds.feeds.comp_usd_feed import comp_usd_median_feed
 from telliot_feeds.feeds.crv_usd_feed import crv_usd_median_feed
 from telliot_feeds.feeds.dai_usd_feed import dai_usd_median_feed
@@ -136,6 +137,7 @@ CATALOG_FEEDS: Dict[str, DataFeed[Any]] = {
     "wsteth-eth-spot": wsteth_eth_median_feed,
     "op-usd-spot": op_usd_median_feed,
     "grt-usd-spot": grt_usd_median_feed,
+    "cny-usd-spot": cny_usd_median_feed,
 }
 
 DATAFEED_BUILDER_MAPPING: Dict[str, DataFeed[Any]] = {

--- a/src/telliot_feeds/feeds/cny_usd_feed.py
+++ b/src/telliot_feeds/feeds/cny_usd_feed.py
@@ -1,0 +1,21 @@
+"""
+EUR/USD SpotPrice DataFeed
+"""
+from telliot_feeds.datafeed import DataFeed
+from telliot_feeds.queries.price.spot_price import SpotPrice
+from telliot_feeds.sources.price.currency.coinbase import CoinbaseCurrencyPriceSource
+from telliot_feeds.sources.price.currency.openexchangerate import OpenExchangeRateCurrencyPriceSource
+from telliot_feeds.sources.price_aggregator import PriceAggregator
+
+cny_usd_median_feed = DataFeed(
+    query=SpotPrice(asset="CNY", currency="USD"),
+    source=PriceAggregator(
+        asset="cny",
+        currency="usd",
+        algorithm="median",
+        sources=[
+            CoinbaseCurrencyPriceSource(asset="cny", currency="usd"),
+            OpenExchangeRateCurrencyPriceSource(asset="cny", currency="usd"),
+        ],
+    ),
+)

--- a/src/telliot_feeds/feeds/cny_usd_feed.py
+++ b/src/telliot_feeds/feeds/cny_usd_feed.py
@@ -1,5 +1,5 @@
 """
-EUR/USD SpotPrice DataFeed
+CNY/USD SpotPrice DataFeed
 """
 from telliot_feeds.datafeed import DataFeed
 from telliot_feeds.queries.price.spot_price import SpotPrice

--- a/src/telliot_feeds/queries/price/spot_price.py
+++ b/src/telliot_feeds/queries/price/spot_price.py
@@ -61,6 +61,7 @@ SPOT_PRICE_PAIRS = [
     "WSTETH/ETH",
     "OP/USD",
     "GRT/USD",
+    "CNY/USD",
 ]
 
 

--- a/src/telliot_feeds/queries/query_catalog.py
+++ b/src/telliot_feeds/queries/query_catalog.py
@@ -367,3 +367,15 @@ query_catalog.add_entry(
     title="GRT/USD spot price",
     q=SpotPrice(asset="grt", currency="usd"),
 )
+
+query_catalog.add_entry(
+    tag="cny-usd-spot",
+    title="CNY/USD spot price",
+    q=SpotPrice(asset="cny", currency="usd"),
+)
+
+query_catalog.add_entry(
+    tag="eth-jpy-spot",
+    title="ETH/JPY spot price",
+    q=SpotPrice(asset="eth", currency="jpy"),
+)

--- a/tests/feeds/test_cny_usd_feed.py
+++ b/tests/feeds/test_cny_usd_feed.py
@@ -1,0 +1,22 @@
+import statistics
+
+import pytest
+
+from telliot_feeds.feeds.cny_usd_feed import cny_usd_median_feed
+
+
+@pytest.mark.asyncio
+async def test_cny_usd_median_feed():
+    """Retrieve median CNY/USD price."""
+    v, _ = await cny_usd_median_feed.source.fetch_new_datapoint()
+
+    assert v is not None
+    assert v > 0
+    print(f"CNY/USD Price: {v}")
+
+    # Get list of data sources from sources dict
+    source_prices = [source.latest[0] for source in cny_usd_median_feed.source.sources]
+    print(source_prices)
+
+    # Make sure error is less than decimal tolerance
+    assert (v - statistics.median(source_prices)) < 10**-6


### PR DESCRIPTION
Summary
This PR makes two improvements to Telliot:
- Fixes the eur/usd spot price feed that was removed from query_catalog.py.
- Adds spot price feed add for CNY/USD. 

Changes were made following the telliot-feeds docs for adding a spot price, but no local tests were done. I tested the feeds by reporting on goerli / mumbai. The APIs all responded correctly. 

Here is the test report for CNY/USD:
https://mumbai.polygonscan.com/tx/0x9560fa117d56f5bf42a7b52e7e8571ff2e6c06cd8fc262425dcfedce76e2b12b
Here's the test report for ETH/JPY:
https://goerli.etherscan.io/tx/0x4366fa669cba4e94130a31e63b100147b6e472e4aa91713d767f0f47253bf6be