### PR TITLE
added brl-usd feed

### DIFF
--- a/src/telliot_feeds/feeds/__init__.py
+++ b/src/telliot_feeds/feeds/__init__.py
@@ -9,6 +9,7 @@ from telliot_feeds.feeds.avax_usd_feed import avax_usd_median_feed
 from telliot_feeds.feeds.badger_usd_feed import badger_usd_median_feed
 from telliot_feeds.feeds.bch_usd_feed import bch_usd_median_feed
 from telliot_feeds.feeds.bct_usd_feed import bct_usd_median_feed
+from telliot_feeds.feeds.brl_usd_feed import brl_usd_median_feed
 from telliot_feeds.feeds.btc_usd_feed import btc_usd_median_feed
 from telliot_feeds.feeds.cny_usd_feed import cny_usd_median_feed
 from telliot_feeds.feeds.comp_usd_feed import comp_usd_median_feed
@@ -138,6 +139,7 @@ CATALOG_FEEDS: Dict[str, DataFeed[Any]] = {
     "op-usd-spot": op_usd_median_feed,
     "grt-usd-spot": grt_usd_median_feed,
     "cny-usd-spot": cny_usd_median_feed,
+    "brl-usd-spot": brl_usd_median_feed,
 }
 
 DATAFEED_BUILDER_MAPPING: Dict[str, DataFeed[Any]] = {

--- a/src/telliot_feeds/feeds/brl_usd_feed.py
+++ b/src/telliot_feeds/feeds/brl_usd_feed.py
@@ -1,0 +1,21 @@
+"""
+BRL/USD SpotPrice DataFeed
+"""
+from telliot_feeds.datafeed import DataFeed
+from telliot_feeds.queries.price.spot_price import SpotPrice
+from telliot_feeds.sources.price.currency.coinbase import CoinbaseCurrencyPriceSource
+from telliot_feeds.sources.price.currency.openexchangerate import OpenExchangeRateCurrencyPriceSource
+from telliot_feeds.sources.price_aggregator import PriceAggregator
+
+brl_usd_median_feed = DataFeed(
+    query=SpotPrice(asset="BRL", currency="USD"),
+    source=PriceAggregator(
+        asset="brl",
+        currency="usd",
+        algorithm="median",
+        sources=[
+            CoinbaseCurrencyPriceSource(asset="brl", currency="usd"),
+            OpenExchangeRateCurrencyPriceSource(asset="brl", currency="usd"),
+        ],
+    ),
+)

--- a/src/telliot_feeds/queries/price/spot_price.py
+++ b/src/telliot_feeds/queries/price/spot_price.py
@@ -62,6 +62,7 @@ SPOT_PRICE_PAIRS = [
     "OP/USD",
     "GRT/USD",
     "CNY/USD",
+    "BRL/USD",
 ]
 
 

--- a/src/telliot_feeds/queries/query_catalog.py
+++ b/src/telliot_feeds/queries/query_catalog.py
@@ -379,3 +379,9 @@ query_catalog.add_entry(
     title="ETH/JPY spot price",
     q=SpotPrice(asset="eth", currency="jpy"),
 )
+
+query_catalog.add_entry(
+    tag="brl-usd-spot",
+    title="BRL/USD spot price",
+    q=SpotPrice(asset="brl", currency="usd"),
+)

--- a/tests/feeds/test_brl_usd_feed.py
+++ b/tests/feeds/test_brl_usd_feed.py
@@ -1,0 +1,22 @@
+import statistics
+
+import pytest
+
+from telliot_feeds.feeds.brl_usd_feed import brl_usd_median_feed
+
+
+@pytest.mark.asyncio
+async def test_brl_usd_median_feed():
+    """Retrieve median BRL/USD price."""
+    v, _ = await brl_usd_median_feed.source.fetch_new_datapoint()
+
+    assert v is not None
+    assert v > 0
+    print(f"BRL/USD Price: {v}")
+
+    # Get list of data sources from sources dict
+    source_prices = [source.latest[0] for source in brl_usd_median_feed.source.sources]
+    print(source_prices)
+
+    # Make sure error is less than decimal tolerance
+    assert (v - statistics.median(source_prices)) < 10**-6


### PR DESCRIPTION
### Summary
This PR makes changes neccessary for adding a new spot price feed: BRL/USD

### Steps Taken to QA Changes
Tested by reporting on goerli testnet. Log confirmed that two sources were successfully queried and the values were accurate. https://goerli.etherscan.io/tx/0x5ecb0eafa4fa09cd1361e650a2b92b56a0332794f236b49c3c0533415159bab6

![Screenshot 2023-06-20 at 12 08 41 PM](https://github.com/tellor-io/telliot-feeds/assets/72078372/e8721b80-1669-4c41-9fe5-c02bb53ee972)

A local test file was added for pytest.

This pull request is:

- [x] A feature implementation