### PR TITLE
adding Origin feeds: OUSD/USD and OETH/ETH

### DIFF
--- a/src/telliot_feeds/feeds/__init__.py
+++ b/src/telliot_feeds/feeds/__init__.py
@@ -46,8 +46,10 @@ from telliot_feeds.feeds.mimicry.nft_index_feed import mimicry_nft_market_index_
 from telliot_feeds.feeds.mkr_usd_feed import mkr_usd_median_feed
 from telliot_feeds.feeds.numeric_api_response_feed import numeric_api_response_feed
 from telliot_feeds.feeds.numeric_api_response_manual_feed import numeric_api_response_manual_feed
+from telliot_feeds.feeds.oeth_eth_feed import oeth_eth_median_feed
 from telliot_feeds.feeds.olympus import ohm_eth_median_feed
 from telliot_feeds.feeds.op_usd_feed import op_usd_median_feed
+from telliot_feeds.feeds.ousd_usd_feed import ousd_usd_median_feed
 from telliot_feeds.feeds.pls_usd_feed import pls_usd_median_feed
 from telliot_feeds.feeds.rai_usd_feed import rai_usd_median_feed
 from telliot_feeds.feeds.reth_btc_feed import reth_btc_median_feed
@@ -140,6 +142,8 @@ CATALOG_FEEDS: Dict[str, DataFeed[Any]] = {
     "grt-usd-spot": grt_usd_median_feed,
     "cny-usd-spot": cny_usd_median_feed,
     "brl-usd-spot": brl_usd_median_feed,
+    "ousd-usd-spot": ousd_usd_median_feed,
+    "oeth-eth-spot": oeth_eth_median_feed,
 }
 
 DATAFEED_BUILDER_MAPPING: Dict[str, DataFeed[Any]] = {

--- a/src/telliot_feeds/feeds/oeth_eth_feed.py
+++ b/src/telliot_feeds/feeds/oeth_eth_feed.py
@@ -1,0 +1,21 @@
+from telliot_feeds.datafeed import DataFeed
+from telliot_feeds.queries.price.spot_price import SpotPrice
+from telliot_feeds.sources.price.spot.coingecko import CoinGeckoSpotPriceSource
+from telliot_feeds.sources.price_aggregator import PriceAggregator
+
+# from telliot_feeds.sources.price.spot.curvefi import CurveFinanceSpotPriceSource
+# from telliot_feeds.sources.price.spot.uniswapV3 import UniswapV3PriceSource
+
+oeth_eth_median_feed = DataFeed(
+    query=SpotPrice(asset="OETH", currency="ETH"),
+    source=PriceAggregator(
+        asset="oeth",
+        currency="eth",
+        algorithm="median",
+        sources=[
+            CoinGeckoSpotPriceSource(asset="oeth", currency="eth"),
+            # UniswapV3PriceSource(asset="oeth", currency="eth"),
+            # CurveFinanceSpotPriceSource(asset="oeth", currency="eth"),
+        ],
+    ),
+)

--- a/src/telliot_feeds/feeds/ousd_usd_feed.py
+++ b/src/telliot_feeds/feeds/ousd_usd_feed.py
@@ -1,0 +1,21 @@
+from telliot_feeds.datafeed import DataFeed
+from telliot_feeds.queries.price.spot_price import SpotPrice
+from telliot_feeds.sources.price.spot.coingecko import CoinGeckoSpotPriceSource
+from telliot_feeds.sources.price.spot.uniswapV3 import UniswapV3PriceSource
+from telliot_feeds.sources.price_aggregator import PriceAggregator
+
+# from telliot_feeds.sources.price.spot.curvefi import CurveFinanceSpotPriceSource
+
+ousd_usd_median_feed = DataFeed(
+    query=SpotPrice(asset="OUSD", currency="USD"),
+    source=PriceAggregator(
+        asset="ousd",
+        currency="usd",
+        algorithm="median",
+        sources=[
+            CoinGeckoSpotPriceSource(asset="ousd", currency="usd"),
+            UniswapV3PriceSource(asset="ousd", currency="usd"),
+            # CurveFinanceSpotPriceSource(asset="ousd", currency="usd"),
+        ],
+    ),
+)

--- a/src/telliot_feeds/queries/price/spot_price.py
+++ b/src/telliot_feeds/queries/price/spot_price.py
@@ -63,6 +63,8 @@ SPOT_PRICE_PAIRS = [
     "GRT/USD",
     "CNY/USD",
     "BRL/USD",
+    "OUSD/USD",
+    "OETH/ETH",
 ]
 
 

--- a/src/telliot_feeds/queries/query_catalog.py
+++ b/src/telliot_feeds/queries/query_catalog.py
@@ -385,3 +385,15 @@ query_catalog.add_entry(
     title="BRL/USD spot price",
     q=SpotPrice(asset="brl", currency="usd"),
 )
+
+query_catalog.add_entry(
+    tag="ousd-usd-spot",
+    title="OUSD/USD spot price",
+    q=SpotPrice(asset="ousd", currency="usd"),
+)
+
+query_catalog.add_entry(
+    tag="oeth-eth-spot",
+    title="OETH/ETH spot price",
+    q=SpotPrice(asset="oeth", currency="eth"),
+)

--- a/src/telliot_feeds/sources/price/spot/coingecko.py
+++ b/src/telliot_feeds/sources/price/spot/coingecko.py
@@ -54,6 +54,8 @@ coingecko_coin_id = {
     "op": "optimism",
     "grt": "the-graph",
     "pls": "pulsechain",
+    "oeth": "origin-ether",
+    "ousd": "origin-dollar",
 }
 
 

--- a/src/telliot_feeds/sources/price/spot/uniswapV3.py
+++ b/src/telliot_feeds/sources/price/spot/uniswapV3.py
@@ -21,6 +21,7 @@ uniswapV3_map = {
     "steth": "0xae7ab96520de3a18e5e111b5eaab095312d7fe84",
     "reth": "0xae78736cd615f374d3085123a210448e74fc6393",
     "pls": "0xa882606494d86804b5514e07e6bd2d6a6ee6d68a",
+    "ousd": "0x2a8e1e676ec238d8a992307b495b45b3feaa5e86",
 }
 
 


### PR DESCRIPTION
### Summary
This pull request adds OUSD/USD and OETH/ETH feeds in response to dataSpecs issues https://github.com/tellor-io/dataSpecs/issues/124 and https://github.com/tellor-io/dataSpecs/issues/123. I will continue to work on adding more / multiple sources for both of these feeds, but wanted to push the branch so that others can contribute. 

### Steps Taken to QA Changes
Both feeds have been tested via local installation submitting to testnet Tellor contracts. 

OUSD/USD spot: https://goerli.etherscan.io/tx/0x319eee38c748fe571561b5d482c2c49ca7fb2611b5e16061a2c5ea2044cd086f

OETH/ETH spot: https://mumbai.polygonscan.com//tx/0x97b1fdd43bfe289b780507c039b02a12b062ac2bf35ad045d5c219e63daa7240

See the linked dataSpecs issues for more possible sources. Thanks for reading!

This pull request is:
- [X] A feature implementation