### PR TITLE
Add unsafe option to skip confirmation prompts

### DIFF
--- a/src/telliot_feeds/cli/commands/report.py
+++ b/src/telliot_feeds/cli/commands/report.py
@@ -184,6 +184,7 @@ async def report(
     gas_multiplier: int,
     max_priority_fee_range: int,
     ignore_tbr: bool,
+    unsafe: bool,
 ) -> None:
     """Report values to Tellor oracle"""
     ctx.obj["ACCOUNT_NAME"] = account_str
@@ -200,7 +201,7 @@ async def report(
     # Initialize telliot core app using CLI context
     async with reporter_cli_core(ctx) as core:
 
-        core._config, account = setup_config(core.config, account_name=account_str)
+        core._config, account = setup_config(core.config, account_name=account_str, unsafe=unsafe)
 
         endpoint = check_endpoint(core._config)
 
@@ -262,7 +263,8 @@ async def report(
             min_native_token_balance=min_native_token_balance,
         )
 
-        _ = input("Press [ENTER] to confirm settings.")
+        if not unsafe:
+            _ = input("Press [ENTER] to confirm settings.")
 
         contracts = core.get_tellor360_contracts() if tellor_360 else core.get_tellorflex_contracts()
 

--- a/src/telliot_feeds/cli/utils.py
+++ b/src/telliot_feeds/cli/utils.py
@@ -306,6 +306,14 @@ def common_options(f: Callable[..., Any]) -> Callable[..., Any]:
         type=str,
     )
     @click.option(
+        "--unsafe/--safe",
+        "-u/-sf",
+        "unsafe",
+        help="Disables config confirmation prompts",
+        required=False,
+        default=True,
+    )
+    @click.option(
         "--query-tag",
         "-qt",
         "query_tag",

--- a/src/telliot_feeds/utils/cfg.py
+++ b/src/telliot_feeds/utils/cfg.py
@@ -15,7 +15,9 @@ from telliot_feeds.utils.log import get_logger
 logger = get_logger(__name__)
 
 
-def setup_config(cfg: TelliotConfig, account_name: str) -> Tuple[TelliotConfig, Optional[ChainedAccount]]:
+def setup_config(
+    cfg: TelliotConfig, account_name: str, unsafe: bool = False
+) -> Tuple[TelliotConfig, Optional[ChainedAccount]]:
     """Setup TelliotConfig via CLI if not already configured
 
     Inputs:
@@ -50,13 +52,19 @@ def setup_config(cfg: TelliotConfig, account_name: str) -> Tuple[TelliotConfig, 
     else:
         click.echo("No accounts set.")
 
-    keep_settings = click.confirm("Proceed with current settings (y) or update (n)?", default=True)
+    if unsafe:
+        keep_settings = True
+    else:
+        keep_settings = click.confirm("Proceed with current settings (y) or update (n)?", default=True)
 
     if keep_settings:
         click.echo("Keeping current settings...")
         return cfg, accounts[0] if accounts else None
 
-    want_to_update_chain_id = click.confirm(f"Chain_id is {cfg.main.chain_id}. Do you want to update it?")
+    if unsafe:
+        want_to_update_chain_id = False
+    else:
+        want_to_update_chain_id = click.confirm(f"Chain_id is {cfg.main.chain_id}. Do you want to update it?")
 
     if want_to_update_chain_id:  # noqa: F821
         new_chain_id = click.prompt("Enter a new chain id", type=int)


### PR DESCRIPTION
<!-- Make sure that your title neatly summarizes the proposed changes -->

### Summary
<!-- Provide a short overview of the change and the value it adds -->
- Creates `-u` option for unsafe mode, which skips configuration prompts. Default is False, so the default will prompt you. This is a draft, so that can be changed based on further discussion.
- Closes #693 

### Steps Taken to QA Changes
<!-- Describe the steps that you have taken to make sure that your changes work as intended without breaking other functionality. These steps should be reproducible and easy to follow for other QA testers-->
- WIP

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)
-->

This pull request is:

- [ ] A documentation error, docs update, or typographical error fix
	- No tests or issue needed
- [ ] A code fix
	- Please reference the related issue by including "Closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a bug report issue 
	- Please include tests. Fixes without tests will not be accepted unless it's related to the documentation only.
    - Please make sure docs are updated if need be
- [x] A feature implementation
	- Please reference the related issue by including "Closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a feature enhancement issue 
	- Please include tests
    - Please make sure docs updates are both thorough and easy to reproduce by somebody with limited knowledge of the feature that you are submitting


**Happy engineering!**