### PR TITLE
WLD/USD & SWETH/USD Spot Price feeds & Removed Dead Testnet From Tests

### DIFF
--- a/src/telliot_feeds/feeds/__init__.py
+++ b/src/telliot_feeds/feeds/__init__.py
@@ -69,6 +69,7 @@ from telliot_feeds.feeds.steth_btc_feed import steth_btc_median_feed
 from telliot_feeds.feeds.steth_usd_feed import steth_usd_median_feed
 from telliot_feeds.feeds.string_query_feed import string_query_feed
 from telliot_feeds.feeds.sushi_usd_feed import sushi_usd_median_feed
+from telliot_feeds.feeds.sweth_usd_feed import sweth_usd_median_feed
 from telliot_feeds.feeds.tellor_rng_feed import tellor_rng_feed
 from telliot_feeds.feeds.tellor_rng_manual_feed import tellor_rng_manual_feed
 from telliot_feeds.feeds.trb_usd_feed import trb_usd_median_feed
@@ -79,6 +80,7 @@ from telliot_feeds.feeds.usdc_usd_feed import usdc_usd_median_feed
 from telliot_feeds.feeds.usdt_usd_feed import usdt_usd_median_feed
 from telliot_feeds.feeds.uspce_feed import uspce_feed
 from telliot_feeds.feeds.vesq import vsq_usd_median_feed
+from telliot_feeds.feeds.wld_usd_feed import wld_usd_median_feed
 from telliot_feeds.feeds.wsteth_feed import wsteth_eth_median_feed
 from telliot_feeds.feeds.wsteth_feed import wsteth_usd_median_feed
 from telliot_feeds.feeds.xdai_usd_feed import xdai_usd_median_feed
@@ -154,6 +156,8 @@ CATALOG_FEEDS: Dict[str, DataFeed[Any]] = {
     "soy-usd-custom": soy,
     "ousd-usd-spot": ousd_usd_median_feed,
     "oeth-eth-spot": oeth_eth_median_feed,
+    "wld-usd-spot": wld_usd_median_feed,
+    "sweth-usd-spot": sweth_usd_median_feed,
 }
 
 DATAFEED_BUILDER_MAPPING: Dict[str, DataFeed[Any]] = {

--- a/src/telliot_feeds/feeds/sweth_usd_feed.py
+++ b/src/telliot_feeds/feeds/sweth_usd_feed.py
@@ -1,0 +1,18 @@
+from telliot_feeds.datafeed import DataFeed
+from telliot_feeds.queries.price.spot_price import SpotPrice
+from telliot_feeds.sources.price.spot.coingecko import CoinGeckoSpotPriceSource
+from telliot_feeds.sources.price.spot.uniswapV3 import UniswapV3PriceSource
+from telliot_feeds.sources.price_aggregator import PriceAggregator
+
+sweth_usd_median_feed = DataFeed(
+    query=SpotPrice(asset="SWETH", currency="USD"),
+    source=PriceAggregator(
+        asset="sweth",
+        currency="usd",
+        algorithm="median",
+        sources=[
+            CoinGeckoSpotPriceSource(asset="sweth", currency="usd"),
+            UniswapV3PriceSource(asset="sweth", currency="usd"),
+        ],
+    ),
+)

--- a/src/telliot_feeds/feeds/wld_usd_feed.py
+++ b/src/telliot_feeds/feeds/wld_usd_feed.py
@@ -1,0 +1,16 @@
+from telliot_feeds.datafeed import DataFeed
+from telliot_feeds.queries.price.spot_price import SpotPrice
+from telliot_feeds.sources.price.spot.coingecko import CoinGeckoSpotPriceSource
+from telliot_feeds.sources.price_aggregator import PriceAggregator
+
+wld_usd_median_feed = DataFeed(
+    query=SpotPrice(asset="WLD", currency="USD"),
+    source=PriceAggregator(
+        asset="wld",
+        currency="usd",
+        algorithm="median",
+        sources=[
+            CoinGeckoSpotPriceSource(asset="wld", currency="usd")
+        ],
+    ),
+)

--- a/src/telliot_feeds/feeds/wld_usd_feed.py
+++ b/src/telliot_feeds/feeds/wld_usd_feed.py
@@ -9,8 +9,6 @@ wld_usd_median_feed = DataFeed(
         asset="wld",
         currency="usd",
         algorithm="median",
-        sources=[
-            CoinGeckoSpotPriceSource(asset="wld", currency="usd")
-        ],
+        sources=[CoinGeckoSpotPriceSource(asset="wld", currency="usd")],
     ),
 )

--- a/src/telliot_feeds/queries/price/spot_price.py
+++ b/src/telliot_feeds/queries/price/spot_price.py
@@ -55,6 +55,7 @@ SPOT_PRICE_PAIRS = [
     "YFI/USD",
     "STETH/BTC",
     "STETH/USD",
+    "SWETH/USD",
     "RETH/BTC",
     "RETH/USD",
     "WSTETH/USD",
@@ -65,6 +66,7 @@ SPOT_PRICE_PAIRS = [
     "BRL/USD",
     "OUSD/USD",
     "OETH/ETH",
+    "WLD/USD",
 ]
 
 

--- a/src/telliot_feeds/queries/query_catalog.py
+++ b/src/telliot_feeds/queries/query_catalog.py
@@ -429,3 +429,15 @@ query_catalog.add_entry(
     title="OETH/ETH spot price",
     q=SpotPrice(asset="oeth", currency="eth"),
 )
+
+query_catalog.add_entry(
+    tag="wld-usd-spot",
+    title="WLD/USD spot price",
+    q=SpotPrice(asset="wld", currency="usd"),
+)
+
+query_catalog.add_entry(
+    tag="sweth-usd-spot",
+    title="SWETH/USD spot price",
+    q=SpotPrice(asset="sweth", currency="usd"),
+)

--- a/src/telliot_feeds/sources/price/spot/coingecko.py
+++ b/src/telliot_feeds/sources/price/spot/coingecko.py
@@ -56,6 +56,8 @@ coingecko_coin_id = {
     "pls": "pulsechain",
     "oeth": "origin-ether",
     "ousd": "origin-dollar",
+    "sweth": "sweth",
+    "wld": "worldcoin",
 }
 
 

--- a/src/telliot_feeds/sources/price/spot/uniswapV3.py
+++ b/src/telliot_feeds/sources/price/spot/uniswapV3.py
@@ -22,6 +22,7 @@ uniswapV3_map = {
     "reth": "0xae78736cd615f374d3085123a210448e74fc6393",
     "pls": "0xa882606494d86804b5514e07e6bd2d6a6ee6d68a",
     "ousd": "0x2a8e1e676ec238d8a992307b495b45b3feaa5e86",
+    "sweth": "0xf951e335afb289353dc249e82926178eac7ded78",
 }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -160,16 +160,6 @@ def mumbai_test_cfg():
 
 
 @pytest.fixture(scope="function", autouse=True)
-def rinkeby_test_cfg():
-    return local_node_cfg(chain_id=4)
-
-
-@pytest.fixture(scope="function", autouse=True)
-def ropsten_test_cfg():
-    return local_node_cfg(chain_id=3)
-
-
-@pytest.fixture(scope="function", autouse=True)
 def goerli_test_cfg():
     return local_node_cfg(chain_id=5)
 

--- a/tests/feeds/test_sweth_usd_feed.py
+++ b/tests/feeds/test_sweth_usd_feed.py
@@ -1,0 +1,22 @@
+import statistics
+
+import pytest
+
+from telliot_feeds.feeds.sweth_usd_feed import sweth_usd_median_feed
+
+
+@pytest.mark.asyncio
+async def test_sweth_usd_median_feed(caplog):
+    """Retrieve median SWETH/USD price."""
+    v, _ = await sweth_usd_median_feed.source.fetch_new_datapoint()
+
+    assert v is not None
+    assert v > 0
+    assert "sources used in aggregate: 2" in caplog.text.lower()
+    print(f"SWETH/USD Price: {v}")
+
+    # Get list of data sources from sources dict
+    source_prices = [source.latest[0] for source in sweth_usd_median_feed.source.sources if source.latest[0]]
+
+    # Make sure error is less than decimal tolerance
+    assert (v - statistics.median(source_prices)) < 10**-6

--- a/tests/feeds/test_wld_usd_feed.py
+++ b/tests/feeds/test_wld_usd_feed.py
@@ -1,0 +1,21 @@
+import statistics
+
+import pytest
+
+from telliot_feeds.feeds.wld_usd_feed import wld_usd_median_feed
+
+
+@pytest.mark.asyncio
+async def test_wld_asset_price_feed():
+    """Retrieve median WLD/USD price."""
+    v, _ = await wld_usd_median_feed.source.fetch_new_datapoint()
+
+    assert v is not None
+    assert v > 0
+    print(f"WLD/USD Price: {v}")
+
+    # Get list of data sources from sources dict
+    source_prices = [source.latest[0] for source in wld_usd_median_feed.source.sources]
+
+    # Make sure error is less than decimal tolerance
+    assert (v - statistics.median(source_prices)) < 10**-6


### PR DESCRIPTION
This pull request adds new feeds to telliot. Rinkeby and Ropsten checks were removed from conftest.py. 

### Steps Taken to QA Changes
The new feeds were tested with pytest locally, and submitted to sepolia testnet:
https://sepolia.etherscan.io/tx/0x488373ed824c5870bbd289c74a163e8e008147414d0e79bf515afcdd8a49aed2
https://sepolia.etherscan.io/tx/0x619b09b06c8cd31312350578f2a0704338095daba9c32db392410af58b5a69f2

We will need to revisit these feeds to add more robust sources if / when they are used for DeFI functions.

### Checklist
This pull request is:

- [ ] A documentation error, docs update, or typographical error fix
	- No tests or issue needed
- [ ] A code fix
	- Please reference the related issue by including "Closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a bug report issue 
	- Please include tests. Fixes without tests will not be accepted unless it's related to the documentation only.
    - Please make sure docs are updated if need be
- [x] A feature implementation
	- Please reference the related issue by including "Closes `<link to issue>`" in this Pull Request's summary section. 
        - If no issue exists, please create a feature enhancement issue 
	- Please include tests
    - Please make sure docs updates are both thorough and easy to reproduce by somebody with limited knowledge of the feature that you are submitting