### PR TITLE
Add CBETH/USD feed

### DIFF
--- a/src/telliot_feeds/feeds/__init__.py
+++ b/src/telliot_feeds/feeds/__init__.py
@@ -11,6 +11,7 @@ from telliot_feeds.feeds.bch_usd_feed import bch_usd_median_feed
 from telliot_feeds.feeds.bct_usd_feed import bct_usd_median_feed
 from telliot_feeds.feeds.brl_usd_feed import brl_usd_median_feed
 from telliot_feeds.feeds.btc_usd_feed import btc_usd_median_feed
+from telliot_feeds.feeds.cbeth_usd_feed import cbeth_usd_median_feed
 from telliot_feeds.feeds.cny_usd_feed import cny_usd_median_feed
 from telliot_feeds.feeds.comp_usd_feed import comp_usd_median_feed
 from telliot_feeds.feeds.crv_usd_feed import crv_usd_median_feed
@@ -160,6 +161,7 @@ CATALOG_FEEDS: Dict[str, DataFeed[Any]] = {
     "wld-usd-spot": wld_usd_median_feed,
     "sweth-usd-spot": sweth_usd_median_feed,
     "diva-usd-spot": diva_usd_median_feed,
+    "cbeth-usd-spot": cbeth_usd_median_feed,
 }
 
 DATAFEED_BUILDER_MAPPING: Dict[str, DataFeed[Any]] = {

--- a/src/telliot_feeds/feeds/cbeth_usd_feed.py
+++ b/src/telliot_feeds/feeds/cbeth_usd_feed.py
@@ -14,7 +14,7 @@ cbeth_usd_median_feed = DataFeed(
         sources=[
             CoinGeckoSpotPriceSource(asset="cbeth", currency="usd"),
             UniswapV3PriceSource(asset="cbeth", currency="usd"),
-            CoinpaprikaSpotPriceSource(asset="cbeth-coinbase-wrapped-staked-eth", currency="usd")
+            CoinpaprikaSpotPriceSource(asset="cbeth-coinbase-wrapped-staked-eth", currency="usd"),
         ],
     ),
 )

--- a/src/telliot_feeds/feeds/cbeth_usd_feed.py
+++ b/src/telliot_feeds/feeds/cbeth_usd_feed.py
@@ -1,0 +1,20 @@
+from telliot_feeds.datafeed import DataFeed
+from telliot_feeds.queries.price.spot_price import SpotPrice
+from telliot_feeds.sources.price.spot.coingecko import CoinGeckoSpotPriceSource
+from telliot_feeds.sources.price.spot.coinpaprika import CoinpaprikaSpotPriceSource
+from telliot_feeds.sources.price.spot.uniswapV3 import UniswapV3PriceSource
+from telliot_feeds.sources.price_aggregator import PriceAggregator
+
+cbeth_usd_median_feed = DataFeed(
+    query=SpotPrice(asset="CBETH", currency="USD"),
+    source=PriceAggregator(
+        asset="cbeth",
+        currency="usd",
+        algorithm="median",
+        sources=[
+            CoinGeckoSpotPriceSource(asset="cbeth", currency="usd"),
+            UniswapV3PriceSource(asset="cbeth", currency="usd"),
+            CoinpaprikaSpotPriceSource(asset="cbeth-coinbase-wrapped-staked-eth", currency="usd")
+        ],
+    ),
+)

--- a/src/telliot_feeds/queries/price/spot_price.py
+++ b/src/telliot_feeds/queries/price/spot_price.py
@@ -68,6 +68,7 @@ SPOT_PRICE_PAIRS = [
     "OETH/ETH",
     "WLD/USD",
     "DIVA/USD",
+    "CBETH/USD",
 ]
 
 

--- a/src/telliot_feeds/queries/query_catalog.py
+++ b/src/telliot_feeds/queries/query_catalog.py
@@ -444,6 +444,12 @@ query_catalog.add_entry(
 
 query_catalog.add_entry(
     tag="diva-usd-spot",
-    title="diva/USD spot price",
+    title="DIVA/USD spot price",
     q=SpotPrice(asset="diva", currency="usd"),
+)
+
+query_catalog.add_entry(
+    tag="cbeth-usd-spot",
+    title="CBETH/USD spot price",
+    q=SpotPrice(asset="cbeth", currency="usd"),
 )

--- a/src/telliot_feeds/sources/price/spot/coingecko.py
+++ b/src/telliot_feeds/sources/price/spot/coingecko.py
@@ -59,6 +59,7 @@ coingecko_coin_id = {
     "sweth": "sweth",
     "wld": "worldcoin",
     "diva": "diva-protocol",
+    "cbeth": "coinbase-wrapped-staked-eth",
 }
 
 

--- a/src/telliot_feeds/sources/price/spot/uniswapV3.py
+++ b/src/telliot_feeds/sources/price/spot/uniswapV3.py
@@ -23,6 +23,7 @@ uniswapV3_map = {
     "pls": "0xa882606494d86804b5514e07e6bd2d6a6ee6d68a",
     "ousd": "0x2a8e1e676ec238d8a992307b495b45b3feaa5e86",
     "sweth": "0xf951e335afb289353dc249e82926178eac7ded78",
+    "cbeth": "0xbe9895146f7af43049ca1c1ae358b0541ea49704",
 }
 
 

--- a/tests/feeds/test_cbeth_usd_feed.py
+++ b/tests/feeds/test_cbeth_usd_feed.py
@@ -1,0 +1,22 @@
+import statistics
+
+import pytest
+
+from telliot_feeds.feeds.cbeth_usd_feed import cbeth_usd_median_feed
+
+
+@pytest.mark.asyncio
+async def test_cbeth_usd_median_feed(caplog):
+    """Retrieve median STETH/USD price."""
+    v, _ = await cbeth_usd_median_feed.source.fetch_new_datapoint()
+
+    assert v is not None
+    assert v > 0
+    assert "sources used in aggregate: 3" in caplog.text.lower()
+    print(f"CBETH/USD Price: {v}")
+
+    # Get list of data sources from sources dict
+    source_prices = [source.latest[0] for source in cbeth_usd_median_feed.source.sources if source.latest[0]]
+
+    # Make sure error is less than decimal tolerance
+    assert (v - statistics.median(source_prices)) < 10**-6


### PR DESCRIPTION
### CBETH/USD Feed
This pull request adds cbETH/USD as the median of three sources: coinGecko, uniswapV3, and coinPaprika.

### Steps Taken to QA Changes
Changes were tested with pytest after running tox styles / typing. Also reported the feed on goerli: 
https://goerli.etherscan.io/tx/0x893ba6517e2ed401719e0be590c2f310f122f206934a59f3be1df5c72093ea91

This pull request is:

- [x] A feature implementation