### PR TITLE
Small Staking Commands fix

### DIFF
--- a/src/telliot_feeds/cli/commands/request_withdraw_stake.py
+++ b/src/telliot_feeds/cli/commands/request_withdraw_stake.py
@@ -36,6 +36,7 @@ async def request_withdraw(
     min_native_token_balance: float,
     gas_multiplier: int,
     max_priority_fee_range: int,
+    unsafe: bool,
 ) -> None:
     """Request withdraw of tokens from oracle"""
     ctx.obj["ACCOUNT_NAME"] = account_str

--- a/src/telliot_feeds/cli/commands/stake.py
+++ b/src/telliot_feeds/cli/commands/stake.py
@@ -39,6 +39,7 @@ async def stake(
     min_native_token_balance: float,
     gas_multiplier: int,
     max_priority_fee_range: int,
+    unsafe: bool,
 ) -> None:
     """Deposit tokens to oracle"""
     ctx.obj["ACCOUNT_NAME"] = account_str

--- a/src/telliot_feeds/cli/commands/withdraw.py
+++ b/src/telliot_feeds/cli/commands/withdraw.py
@@ -32,6 +32,7 @@ async def withdraw(
     min_native_token_balance: float,
     gas_multiplier: int,
     max_priority_fee_range: int,
+    unsafe: bool,
 ) -> None:
     """Withdraw of tokens from oracle"""
     ctx.obj["ACCOUNT_NAME"] = account_str

--- a/src/telliot_feeds/cli/utils.py
+++ b/src/telliot_feeds/cli/utils.py
@@ -231,7 +231,7 @@ def build_query(log: Optional[Callable[[str], None]] = click.echo) -> Any:
     queries = [q for q in AbiQuery.__subclasses__() if q.__name__ not in ("LegacyRequest")]
     options = [q.__name__ for q in queries]
     # Sort options and queries by alphabetical order
-    options, queries = zip(*sorted(zip(options, queries)))
+    options, queries = [zip(*sorted(zip(options, queries)))]
 
     menu = TerminalMenu(options, title=title)
     selected_index = menu.show()


### PR DESCRIPTION
### Summary
Using the following commands gave an error that the `--unsafe` flag was unexpected: 
```
telliot stake
telliot request-withdraw
telliot withdraw
```
Added the unsafe flag to the function definitions for each command. Result is that the commands work as expected, however adding `--unsafe -pwd PASSWORD` does not bypass confirmations for these staking commands.

In my opinion the `--unsafe` flag is really only needed for the report command, so this is an acceptable solution! Let me know what you think if different 🤙