### PR TITLE
Added Custom Price Aggregator & ORDI/USD Spot

### DIFF
--- a/src/telliot_feeds/feeds/__init__.py
+++ b/src/telliot_feeds/feeds/__init__.py
@@ -9,6 +9,7 @@ from telliot_feeds.feeds.avax_usd_feed import avax_usd_median_feed
 from telliot_feeds.feeds.badger_usd_feed import badger_usd_median_feed
 from telliot_feeds.feeds.bch_usd_feed import bch_usd_median_feed
 from telliot_feeds.feeds.bct_usd_feed import bct_usd_median_feed
+from telliot_feeds.feeds.brc20_ordi_usd_feed import ordi_usd_median_feed
 from telliot_feeds.feeds.brl_usd_feed import brl_usd_median_feed
 from telliot_feeds.feeds.btc_usd_feed import btc_usd_median_feed
 from telliot_feeds.feeds.cbeth_usd_feed import cbeth_usd_median_feed
@@ -170,6 +171,7 @@ CATALOG_FEEDS: Dict[str, DataFeed[Any]] = {
     "oeth-usd-spot": oeth_usd_median_feed,
     "pyth-usd-spot": pyth_usd_median_feed,
     "ogv-eth-spot": ogv_eth_median_feed,
+    "brc20-ordi-usd-spot": ordi_usd_median_feed,
 }
 
 DATAFEED_BUILDER_MAPPING: Dict[str, DataFeed[Any]] = {

--- a/src/telliot_feeds/feeds/brc20_ordi_usd_feed.py
+++ b/src/telliot_feeds/feeds/brc20_ordi_usd_feed.py
@@ -1,0 +1,18 @@
+from telliot_feeds.datafeed import DataFeed
+from telliot_feeds.queries.custom_price import CustomPrice
+from telliot_feeds.sources.price.spot.coingecko import CoinGeckoBRC20SpotPriceSource
+from telliot_feeds.sources.custom_price_aggregator import CustomPriceAggregator
+
+ordi_usd_median_feed = DataFeed(
+    query=CustomPrice(identifier="brc20", asset="ordi", currency="btc", unit=""),
+    source=CustomPriceAggregator(
+        identifier="brc20",
+        asset="ordi",
+        currency="usd",
+        unit="",
+        algorithm="median",
+        sources=[
+            CoinGeckoBRC20SpotPriceSource(identifier="brc20", asset="ordi", currency="usd", unit=""),
+        ],
+    ),
+)

--- a/src/telliot_feeds/feeds/brc20_ordi_usd_feed.py
+++ b/src/telliot_feeds/feeds/brc20_ordi_usd_feed.py
@@ -1,7 +1,7 @@
 from telliot_feeds.datafeed import DataFeed
 from telliot_feeds.queries.custom_price import CustomPrice
-from telliot_feeds.sources.price.spot.coingecko import CoinGeckoBRC20SpotPriceSource
 from telliot_feeds.sources.custom_price_aggregator import CustomPriceAggregator
+from telliot_feeds.sources.price.spot.coingecko import CoinGeckoBRC20SpotPriceSource
 
 ordi_usd_median_feed = DataFeed(
     query=CustomPrice(identifier="brc20", asset="ordi", currency="btc", unit=""),

--- a/src/telliot_feeds/queries/price/spot_price.py
+++ b/src/telliot_feeds/queries/price/spot_price.py
@@ -73,6 +73,7 @@ SPOT_PRICE_PAIRS = [
     "OETH/USD",
     "PYTH/USD",
     "OGV/ETH",
+    "ORDI/USD",
 ]
 
 

--- a/src/telliot_feeds/queries/query_catalog.py
+++ b/src/telliot_feeds/queries/query_catalog.py
@@ -477,3 +477,9 @@ query_catalog.add_entry(
     title="OGV/ETH spot price",
     q=SpotPrice(asset="ogv", currency="eth"),
 )
+
+query_catalog.add_entry(
+    tag="brc20-ordi-usd-spot",
+    title="ORDI/USD spot price",
+    q=CustomPrice(identifier="brc20", asset="ordi", currency="usd", unit=""),
+)

--- a/src/telliot_feeds/sources/custom_price_aggregator.py
+++ b/src/telliot_feeds/sources/custom_price_aggregator.py
@@ -1,0 +1,105 @@
+import asyncio
+import statistics
+from dataclasses import dataclass
+from dataclasses import field
+from typing import Callable
+from typing import List
+from typing import Literal
+
+from telliot_feeds.datasource import DataSource
+from telliot_feeds.dtypes.datapoint import datetime_now_utc
+from telliot_feeds.dtypes.datapoint import OptionalDataPoint
+from telliot_feeds.pricing.price_source import PriceSource
+from telliot_feeds.utils.log import get_logger
+
+
+logger = get_logger(__name__)
+
+
+@dataclass
+class CustomPriceAggregator(DataSource[float]):
+
+    # identifier
+    identifier: str = ""
+
+    #: Asset
+    asset: str = ""
+
+    # : Currency of returned price
+    currency: str = ""
+
+    # unit
+    unit: str = ""
+
+    #: Callable algorithm that accepts an iterable of floats
+    algorithm: Literal["median", "mean"] = "median"
+
+    #: Private storage for actual algorithm function
+    _algorithm: Callable[..., float] = field(default=statistics.median, init=False, repr=False)
+
+    #: Data feed sources
+    sources: List[PriceSource] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        if self.algorithm == "median":
+            self._algorithm = statistics.median
+        elif self.algorithm == "mean":
+            self._algorithm = statistics.mean
+
+    def __str__(self) -> str:
+        """Human-readable representation."""
+        asset = self.asset.upper()
+        currency = self.currency.upper()
+        symbol = asset + "/" + currency
+        return f"PriceAggregator {symbol} {self.algorithm}"
+
+    async def update_sources(self) -> List[OptionalDataPoint[float]]:
+        """Update data feed sources
+
+        Returns:
+            Dictionary of updated source values, mapping data source UID
+            to the time-stamped answer for that data source
+        """
+
+        async def gather_inputs() -> List[OptionalDataPoint[float]]:
+            sources = self.sources
+            datapoints = await asyncio.gather(*[source.fetch_new_datapoint() for source in sources])
+            return datapoints
+
+        inputs = await gather_inputs()
+
+        return inputs
+
+    async def fetch_new_datapoint(self) -> OptionalDataPoint[float]:
+        """Update current value with time-stamped value fetched from source
+
+        Args:
+            store:  If true and applicable, updated value will be stored
+                    to the database
+
+        Returns:
+            Current time-stamped value
+        """
+        datapoints = await self.update_sources()
+
+        prices = []
+        for datapoint in datapoints:
+            v, _ = datapoint  # Ignore input timestamps
+            # Check for valid answers
+            if v is not None and isinstance(v, float):
+                prices.append(v)
+
+        if not prices:
+            logger.warning(f"No prices retrieved for {self}.")
+            return None, None
+
+        # Run the algorithm on all valid prices
+        logger.info(f"Running {self.algorithm} on {prices}")
+        result = self._algorithm(prices)
+        datapoint = (result, datetime_now_utc())
+        self.store_datapoint(datapoint)
+
+        logger.info("Feed Price: {} reported at time {}".format(datapoint[0], datapoint[1]))
+        logger.info("Number of sources used in aggregate: {}".format(len(prices)))
+
+        return datapoint


### PR DESCRIPTION
### Summary
Added a BRC20 spot price feed (ORDI/USD) encoded as Custom Price query type. (Tippers will need to be adjusted to include encoding for all 4 CustomPrice parameters)

### Steps Taken to QA Changes
Test submission on sepolia:
https://sepolia.etherscan.io/tx/0x3fc8ec2fcce2af82d933e22bdc444731239b24d007eae825941e2d97ef507d93

This pull request is:

- [x] A feature implementation

<img width="1406" alt="Screenshot 2024-01-05 at 9 05 38 PM" src="https://github.com/tellor-io/telliot-feeds/assets/72078372/7578883e-180a-4fff-b8ff-95f6f861176e">
<img width="536" alt="Screenshot 2024-01-05 at 8 58 52 PM" src="https://github.com/tellor-io/telliot-feeds/assets/72078372/2d360cc6-b6f0-4138-b0f7-ac68948880fa">
<img width="250" alt="Screenshot 2024-01-05 at 8 58 33 PM" src="https://github.com/tellor-io/telliot-feeds/assets/72078372/92275476-c7d2-40a8-99b1-9139e5c5d1a3">