### PR TITLE
Adding LETH_USD feed to telliot-feeds

### DIFF
--- a/src/telliot_feeds/feeds/leth_usd_feed.py
+++ b/src/telliot_feeds/feeds/leth_usd_feed.py
@@ -1,0 +1,17 @@
+from telliot_feeds.datafeed import DataFeed
+from telliot_feeds.queries.price.spot_price import SpotPrice
+from telliot_feeds.sources.price.spot.coingecko import CoinGeckoSpotPriceSource
+from telliot_feeds.sources.price_aggregator import PriceAggregator
+
+
+meth_usd_median_feed = DataFeed(
+    query=SpotPrice(asset="LETH", currency="USD"),
+    source=PriceAggregator(
+        asset="leth",
+        currency="usd",
+        algorithm="median",
+        sources=[
+            CoinGeckoSpotPriceSource(asset="leth", currency="usd"),
+        ],
+    ),
+)

--- a/src/telliot_feeds/sources/price/spot/coingecko.py
+++ b/src/telliot_feeds/sources/price/spot/coingecko.py
@@ -70,6 +70,7 @@ coingecko_coin_id = {
     "usdy": "ondo-us-dollar-yield",
     "wmnt": "wrapped-mantle",
     "primeeth": "prime-staked-eth",
+    "leth": "veno-finance-staked-eth"
 }
 
 


### PR DESCRIPTION
Just added the Datafeed for LETH_USD using only coin gecko has a source. So this will hopefully be updated with more sources in the future
Added LETH token to the CoinGecko asset dict stored in its DataSourceService 