### PR TITLE
remove broken usdm sources

### DIFF
--- a/src/telliot_feeds/feeds/usdm_usd_feed.py
+++ b/src/telliot_feeds/feeds/usdm_usd_feed.py
@@ -2,8 +2,6 @@ from telliot_feeds.datafeed import DataFeed
 from telliot_feeds.queries.price.spot_price import SpotPrice
 from telliot_feeds.sources.price.spot.coingecko import CoinGeckoSpotPriceSource
 from telliot_feeds.sources.price.spot.coinpaprika import CoinpaprikaSpotPriceSource
-from telliot_feeds.sources.price.spot.curvefiprice import CurveFiUSDPriceSource
-from telliot_feeds.sources.price.spot.uniswapV3Pool import UniswapV3PoolPriceSource
 from telliot_feeds.sources.price_aggregator import PriceAggregator
 
 
@@ -15,9 +13,7 @@ usdm_usd_median_feed = DataFeed(
         algorithm="median",
         sources=[
             CoinGeckoSpotPriceSource(asset="usdm", currency="usd"),
-            CurveFiUSDPriceSource(asset="usdm", currency="usd"),
             CoinpaprikaSpotPriceSource(asset="usdm-mountain-protocol-usd", currency="usd"),
-            UniswapV3PoolPriceSource(asset="usdm", currency="usd"),
         ],
     ),
 )

--- a/src/telliot_feeds/sources/price/spot/curvefiprice.py
+++ b/src/telliot_feeds/sources/price/spot/curvefiprice.py
@@ -13,7 +13,6 @@ logger = get_logger(__name__)
 
 
 ethereum_contract_map = {
-    "usdm": "0x59D9356E565Ab3A36dD77763Fc0d87fEaf85508C",
     "sdai": "0x83F20F44975D03b1b09e64809B757c47f942BEeA",
     "sfrax": "0xA663B02CF0a4b149d2aD41910CB81e23e1c41c32",
     "eth": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",

--- a/src/telliot_feeds/sources/price/spot/uniswapV3Pool.py
+++ b/src/telliot_feeds/sources/price/spot/uniswapV3Pool.py
@@ -16,7 +16,6 @@ logger = get_logger(__name__)
 uniswapV3token0__pool_map = {
     "oeth": "0x52299416c469843f4e0d54688099966a6c7d720f",
     "primeeth": "0xb6934f4cf655c93e897514dc7c2af5a143b9ca22",
-    "usdm": "0x4a25dbdf9629b1782c3e2c7de3bdce41f1c7f801",
 }
 
 

--- a/src/telliot_feeds/sources/wusdm_source.py
+++ b/src/telliot_feeds/sources/wusdm_source.py
@@ -10,8 +10,6 @@ from telliot_feeds.pricing.price_service import WebPriceService
 from telliot_feeds.pricing.price_source import PriceSource
 from telliot_feeds.sources.price.spot.coingecko import CoinGeckoSpotPriceSource
 from telliot_feeds.sources.price.spot.coinpaprika import CoinpaprikaSpotPriceSource
-from telliot_feeds.sources.price.spot.curvefiprice import CurveFiUSDPriceSource
-from telliot_feeds.sources.price.spot.uniswapV3Pool import UniswapV3PoolPriceSource
 from telliot_feeds.sources.price_aggregator import PriceAggregator
 from telliot_feeds.utils.log import get_logger
 
@@ -66,9 +64,7 @@ class wUSDMSpotPriceService(WebPriceService):
             algorithm="median",
             sources=[
                 CoinGeckoSpotPriceSource(asset="usdm", currency="usd"),
-                CurveFiUSDPriceSource(asset="usdm", currency="usd"),
                 CoinpaprikaSpotPriceSource(asset="usdm-mountain-protocol-usd", currency=currency),
-                UniswapV3PoolPriceSource(asset="usdm", currency=currency),
             ],
         )
 

--- a/tests/feeds/test_usdm_usd_feed.py
+++ b/tests/feeds/test_usdm_usd_feed.py
@@ -12,7 +12,7 @@ async def test_usdm_usd_median_feed(caplog):
 
     assert v is not None
     assert v > 0
-    assert "sources used in aggregate: 4" in caplog.text.lower()
+    assert "sources used in aggregate: 2" in caplog.text.lower()
     print(f"USDM/ETH Price: {v}")
     # Get list of data sources from sources dict
     source_prices = usdm_usd_median_feed.source.latest[0]

--- a/tests/feeds/test_wusdm_usd_feed.py
+++ b/tests/feeds/test_wusdm_usd_feed.py
@@ -11,7 +11,7 @@ async def test_wusdm_usd_feed(caplog):
 
     assert v is not None
     assert v > 0
-    assert "sources used in aggregate: 4" in caplog.text.lower()
+    assert "sources used in aggregate: 2" in caplog.text.lower()
     print(f"wusdm/usd Price: {v}")
 
     # Get list of data sources from sources dict


### PR DESCRIPTION
### Summary
Quick fix for the usdm/usd feed removing curve and uniswap removed for now. Curve api is returning an incorrect price, and liquidity was pulled from mainnet uniswap.

(will need to try to fix curve and find at least one other source later)
