### PR TITLE
Revert "catch balancer UnboundLocalError"

### DIFF
--- a/src/telliot_feeds/sources/gyd_source.py
+++ b/src/telliot_feeds/sources/gyd_source.py
@@ -109,9 +109,7 @@ class gydSpotPriceService(WebPriceService):
             except requests.exceptions.ConnectTimeout:
                 logger.warning("Timeout Error, No data retrieved from Balancer subgraph")
                 return []
-            except UnboundLocalError:
-                logger.warning("UnboundLocalError, No data retrieved from Balancer subgraph")
-                return []
+
             except Exception as e:
                 logger.warning(f"No data retrieved from Balancer subgraph {e}")
                 return []


### PR DESCRIPTION
### Summary
this catch is no good (the error is preventable in telliot code, it's not an api error)