### PR TITLE
pufeth-usd-spot

### DIFF
--- a/src/telliot_feeds/feeds/__init__.py
+++ b/src/telliot_feeds/feeds/__init__.py
@@ -80,6 +80,7 @@ from telliot_feeds.feeds.op_usd_feed import op_usd_median_feed
 from telliot_feeds.feeds.ousd_usd_feed import ousd_usd_median_feed
 from telliot_feeds.feeds.pls_usd_feed import pls_usd_median_feed
 from telliot_feeds.feeds.primeeth_eth_feed import primeeth_eth_median_feed
+from telliot_feeds.feeds.pufeth_usd_feed import pufeth_usd_median_feed
 from telliot_feeds.feeds.pyth_usd_feed import pyth_usd_median_feed
 from telliot_feeds.feeds.rai_usd_feed import rai_usd_median_feed
 from telliot_feeds.feeds.reth_btc_feed import reth_btc_median_feed
@@ -226,6 +227,7 @@ CATALOG_FEEDS: Dict[str, DataFeed[Any]] = {
     "rseth-usd-spot": rseth_usd_median_feed,
     "tlos-usd-spot": tlos_usd_median_feed,
     "tara-usd-spot": tara_usd_median_feed,
+    "pufeth-usd-spot": pufeth_usd_median_feed,
 }
 
 DATAFEED_BUILDER_MAPPING: Dict[str, DataFeed[Any]] = {

--- a/src/telliot_feeds/feeds/pufeth_usd_feed.py
+++ b/src/telliot_feeds/feeds/pufeth_usd_feed.py
@@ -1,6 +1,7 @@
 from telliot_feeds.datafeed import DataFeed
 from telliot_feeds.queries.price.spot_price import SpotPrice
 from telliot_feeds.sources.price.spot.coingecko import CoinGeckoSpotPriceSource
+from telliot_feeds.sources.price.spot.coinpaprika import CoinpaprikaSpotPriceSource
 from telliot_feeds.sources.price.spot.curvefiprice import CurveFiUSDPriceSource
 from telliot_feeds.sources.price.spot.uniswapV3 import UniswapV3PriceSource
 from telliot_feeds.sources.price_aggregator import PriceAggregator
@@ -14,6 +15,7 @@ pufeth_usd_median_feed = DataFeed(
         algorithm="median",
         sources=[
             CoinGeckoSpotPriceSource(asset="pufeth", currency="usd"),
+            CoinpaprikaSpotPriceSource(asset="pufeth-pufeth", currency="usd"),
             UniswapV3PriceSource(asset="pufeth", currency="usd"),
             CurveFiUSDPriceSource(asset="pufeth", currency="usd"),
         ],

--- a/src/telliot_feeds/feeds/pufeth_usd_feed.py
+++ b/src/telliot_feeds/feeds/pufeth_usd_feed.py
@@ -1,0 +1,21 @@
+from telliot_feeds.datafeed import DataFeed
+from telliot_feeds.queries.price.spot_price import SpotPrice
+from telliot_feeds.sources.price.spot.coingecko import CoinGeckoSpotPriceSource
+from telliot_feeds.sources.price.spot.curvefiprice import CurveFiUSDPriceSource
+from telliot_feeds.sources.price.spot.uniswapV3 import UniswapV3PriceSource
+from telliot_feeds.sources.price_aggregator import PriceAggregator
+
+
+pufeth_usd_median_feed = DataFeed(
+    query=SpotPrice(asset="pufeth", currency="usd"),
+    source=PriceAggregator(
+        asset="pufeth",
+        currency="usd",
+        algorithm="median",
+        sources=[
+            CoinGeckoSpotPriceSource(asset="pufeth", currency="usd"),
+            UniswapV3PriceSource(asset="pufeth", currency="usd"),
+            CurveFiUSDPriceSource(asset="pufeth", currency="usd"),
+        ],
+    ),
+)

--- a/src/telliot_feeds/queries/price/spot_price.py
+++ b/src/telliot_feeds/queries/price/spot_price.py
@@ -97,6 +97,7 @@ SPOT_PRICE_PAIRS = [
     "TLOS/USD",
     "ATLA/USD",
     "TARA/USD",
+    "PUFETH/USD",
 ]
 
 

--- a/src/telliot_feeds/queries/query_catalog.py
+++ b/src/telliot_feeds/queries/query_catalog.py
@@ -644,3 +644,9 @@ query_catalog.add_entry(
     title="TARA/USD spot price",
     q=SpotPrice(asset="tara", currency="usd"),
 )
+
+query_catalog.add_entry(
+    tag="pufeth-usd-spot",
+    title="PUFETH/USD spot price",
+    q=SpotPrice(asset="pufeth", currency="usd"),
+)

--- a/src/telliot_feeds/sources/price/spot/coingecko.py
+++ b/src/telliot_feeds/sources/price/spot/coingecko.py
@@ -89,6 +89,8 @@ coingecko_coin_id = {
     "mode": "mode",
     "tlos": "telos",
     "tara": "taraxa",
+    "pufeth": "pufeth",
+    "stone": "stakestone-ether",
 }
 
 API_KEY = TelliotConfig().api_keys.find(name="coingecko")[0].key

--- a/src/telliot_feeds/sources/price/spot/curvefiprice.py
+++ b/src/telliot_feeds/sources/price/spot/curvefiprice.py
@@ -24,6 +24,7 @@ ethereum_contract_map = {
     "weeth": "0xcd5fe23c85820f7b72d0926fc9b05b43e359b7ee",
     "rseth": "0xa1290d69c65a6fe4df752f95823fae25cb99e5a7",
     "ousd": "0x2a8e1e676ec238d8a992307b495b45b3feaa5e86",
+    "pufeth": "0xd9a442856c234a39a81a089c06451ebaa4306a72",
 }
 
 

--- a/src/telliot_feeds/sources/price/spot/uniswapV3.py
+++ b/src/telliot_feeds/sources/price/spot/uniswapV3.py
@@ -33,6 +33,7 @@ uniswapV3_map = {
     "weeth": "0xcd5fe23c85820f7b72d0926fc9b05b43e359b7ee",
     "wrseth": "0xd2671165570f41bbb3b0097893300b6eb6101e6c",
     "rseth": "0xa1290d69c65a6fe4df752f95823fae25cb99e5a7",
+    "pufeth": "0xd9a442856c234a39a81a089c06451ebaa4306a72",
 }
 
 API_KEY = TelliotConfig().api_keys.find(name="thegraph")[0].key

--- a/tests/feeds/test_pufeth_usd_feed.py
+++ b/tests/feeds/test_pufeth_usd_feed.py
@@ -1,0 +1,22 @@
+import statistics
+
+import pytest
+
+from telliot_feeds.feeds.pufeth_usd_feed import pufeth_usd_median_feed
+
+
+@pytest.mark.asyncio
+async def test_pufeth_usd_median_feed(caplog):
+    """Retrieve median pufeth/usd price."""
+    v, _ = await pufeth_usd_median_feed.source.fetch_new_datapoint()
+
+    assert v is not None
+    assert v > 0
+    assert "sources used in aggregate: 3" in caplog.text.lower()
+    print(f"pufeth/usd Price: {v}")
+
+    # Get list of data sources from sources dict
+    source_prices = [source.latest[0] for source in pufeth_usd_median_feed.source.sources if source.latest[0]]
+
+    # Make sure error is less than decimal tolerance
+    assert (v - statistics.median(source_prices)) < 10**-6

--- a/tests/feeds/test_pufeth_usd_feed.py
+++ b/tests/feeds/test_pufeth_usd_feed.py
@@ -12,7 +12,7 @@ async def test_pufeth_usd_median_feed(caplog):
 
     assert v is not None
     assert v > 0
-    assert "sources used in aggregate: 3" in caplog.text.lower()
+    assert "sources used in aggregate: 4" in caplog.text.lower()
     print(f"pufeth/usd Price: {v}")
 
     # Get list of data sources from sources dict


### PR DESCRIPTION
### Summary
Adds puffer eth (`pufeth-usd-spot`) feed that uses a median of prices sourced from coingecko, uniswap, curvefi, coinpaprika.

### Steps Taken to QA Changes
pytest test added for `pufeth-usd-spot` and reported on sepolia:
https://sepolia.etherscan.io//tx/0xbf096aa072868546fcd712193d18fa9414c9accc56b58a4cea4f124fd7f5cc6a

### Checklist
This pull request is:
- [x] A feature implementation
	- new spot price feed