### PR TITLE
STONE/USD Spot With 2 Sources

### DIFF
--- a/src/telliot_feeds/feeds/__init__.py
+++ b/src/telliot_feeds/feeds/__init__.py
@@ -95,6 +95,7 @@ from telliot_feeds.feeds.snapshot_feed import snapshot_manual_feed
 from telliot_feeds.feeds.spot_price_manual_feed import spot_price_manual_feed
 from telliot_feeds.feeds.steth_btc_feed import steth_btc_median_feed
 from telliot_feeds.feeds.steth_usd_feed import steth_usd_median_feed
+from telliot_feeds.feeds.stone_usd_feed import stone_usd_median_feed
 from telliot_feeds.feeds.string_query_feed import string_query_feed
 from telliot_feeds.feeds.sushi_usd_feed import sushi_usd_median_feed
 from telliot_feeds.feeds.sweth_usd_feed import sweth_usd_median_feed
@@ -228,6 +229,7 @@ CATALOG_FEEDS: Dict[str, DataFeed[Any]] = {
     "tlos-usd-spot": tlos_usd_median_feed,
     "tara-usd-spot": tara_usd_median_feed,
     "pufeth-usd-spot": pufeth_usd_median_feed,
+    "stone-usd-spot": stone_usd_median_feed,
 }
 
 DATAFEED_BUILDER_MAPPING: Dict[str, DataFeed[Any]] = {

--- a/src/telliot_feeds/feeds/stone_usd_feed.py
+++ b/src/telliot_feeds/feeds/stone_usd_feed.py
@@ -1,0 +1,19 @@
+from telliot_feeds.datafeed import DataFeed
+from telliot_feeds.queries.price.spot_price import SpotPrice
+from telliot_feeds.sources.price.spot.coingecko import CoinGeckoSpotPriceSource
+from telliot_feeds.sources.price.spot.coinpaprika import CoinpaprikaSpotPriceSource
+from telliot_feeds.sources.price_aggregator import PriceAggregator
+
+
+stone_usd_median_feed = DataFeed(
+    query=SpotPrice(asset="stone", currency="usd"),
+    source=PriceAggregator(
+        asset="stone",
+        currency="usd",
+        algorithm="median",
+        sources=[
+            CoinGeckoSpotPriceSource(asset="stone", currency="usd"),
+            CoinpaprikaSpotPriceSource(asset="stone-stakestone-ether", currency="usd"),
+        ],
+    ),
+)

--- a/src/telliot_feeds/queries/price/spot_price.py
+++ b/src/telliot_feeds/queries/price/spot_price.py
@@ -98,6 +98,7 @@ SPOT_PRICE_PAIRS = [
     "ATLA/USD",
     "TARA/USD",
     "PUFETH/USD",
+    "STONE/USD",
 ]
 
 

--- a/src/telliot_feeds/queries/query_catalog.py
+++ b/src/telliot_feeds/queries/query_catalog.py
@@ -650,3 +650,9 @@ query_catalog.add_entry(
     title="PUFETH/USD spot price",
     q=SpotPrice(asset="pufeth", currency="usd"),
 )
+
+query_catalog.add_entry(
+    tag="stone-usd-spot",
+    title="STONE/USD spot price",
+    q=SpotPrice(asset="stone", currency="usd"),
+)

--- a/tests/feeds/test_stone_usd_feed.py
+++ b/tests/feeds/test_stone_usd_feed.py
@@ -1,0 +1,22 @@
+import statistics
+
+import pytest
+
+from telliot_feeds.feeds.stone_usd_feed import stone_usd_median_feed
+
+
+@pytest.mark.asyncio
+async def test_stone_usd_median_feed(caplog):
+    """Retrieve median stone/usd price."""
+    v, _ = await stone_usd_median_feed.source.fetch_new_datapoint()
+
+    assert v is not None
+    assert v > 0
+    assert "sources used in aggregate: 2" in caplog.text.lower()
+    print(f"stone/usd Price: {v}")
+
+    # Get list of data sources from sources dict
+    source_prices = [source.latest[0] for source in stone_usd_median_feed.source.sources if source.latest[0]]
+
+    # Make sure error is less than decimal tolerance
+    assert (v - statistics.median(source_prices)) < 10**-6


### PR DESCRIPTION
### Summary
adds a `stone-usd-spot` feed. Tested with local pytest and reported on Sepolia: https://sepolia.etherscan.io//tx/0x488f247c26d6a98e485bfb2dda6cb5990d20fb8c207841dea1d44d7a94379f04

### Checklist
This pull request is:
- [x] A feature implementation
	- stone/usd spot price