### PR TITLE
Remove Coinbase API

### DIFF
--- a/src/telliot_feeds/feeds/aave_usd_feed.py
+++ b/src/telliot_feeds/feeds/aave_usd_feed.py
@@ -1,7 +1,7 @@
 from telliot_feeds.datafeed import DataFeed
 from telliot_feeds.queries.price.spot_price import SpotPrice
-from telliot_feeds.sources.price.spot.coinbase import CoinbaseSpotPriceSource
 from telliot_feeds.sources.price.spot.coingecko import CoinGeckoSpotPriceSource
+from telliot_feeds.sources.price.spot.coinpaprika import CoinpaprikaSpotPriceSource
 from telliot_feeds.sources.price.spot.kraken import KrakenSpotPriceSource
 from telliot_feeds.sources.price_aggregator import PriceAggregator
 
@@ -13,8 +13,8 @@ aave_usd_median_feed = DataFeed(
         algorithm="median",
         sources=[
             CoinGeckoSpotPriceSource(asset="aave", currency="usd"),
-            CoinbaseSpotPriceSource(asset="aave", currency="usd"),
             KrakenSpotPriceSource(asset="aave", currency="usd"),
+            CoinpaprikaSpotPriceSource(asset="aave-new", currency="usd"),
         ],
     ),
 )

--- a/src/telliot_feeds/feeds/avax_usd_feed.py
+++ b/src/telliot_feeds/feeds/avax_usd_feed.py
@@ -1,7 +1,7 @@
 from telliot_feeds.datafeed import DataFeed
 from telliot_feeds.queries.price.spot_price import SpotPrice
-from telliot_feeds.sources.price.spot.coinbase import CoinbaseSpotPriceSource
 from telliot_feeds.sources.price.spot.coingecko import CoinGeckoSpotPriceSource
+from telliot_feeds.sources.price.spot.coinpaprika import CoinpaprikaSpotPriceSource
 from telliot_feeds.sources.price.spot.kraken import KrakenSpotPriceSource
 from telliot_feeds.sources.price_aggregator import PriceAggregator
 
@@ -13,8 +13,8 @@ avax_usd_median_feed = DataFeed(
         algorithm="median",
         sources=[
             CoinGeckoSpotPriceSource(asset="avax", currency="usd"),
-            CoinbaseSpotPriceSource(asset="avax", currency="usd"),
             KrakenSpotPriceSource(asset="avax", currency="usd"),
+            CoinpaprikaSpotPriceSource(asset="avax-avalanche", currency="usd"),
         ],
     ),
 )

--- a/src/telliot_feeds/feeds/badger_usd_feed.py
+++ b/src/telliot_feeds/feeds/badger_usd_feed.py
@@ -1,6 +1,5 @@
 from telliot_feeds.datafeed import DataFeed
 from telliot_feeds.queries.price.spot_price import SpotPrice
-from telliot_feeds.sources.price.spot.coinbase import CoinbaseSpotPriceSource
 from telliot_feeds.sources.price.spot.coingecko import CoinGeckoSpotPriceSource
 from telliot_feeds.sources.price.spot.kraken import KrakenSpotPriceSource
 from telliot_feeds.sources.price_aggregator import PriceAggregator
@@ -13,7 +12,6 @@ badger_usd_median_feed = DataFeed(
         algorithm="median",
         sources=[
             CoinGeckoSpotPriceSource(asset="badger", currency="usd"),
-            CoinbaseSpotPriceSource(asset="badger", currency="usd"),
             KrakenSpotPriceSource(asset="badger", currency="usd"),
         ],
     ),

--- a/src/telliot_feeds/feeds/bch_usd_feed.py
+++ b/src/telliot_feeds/feeds/bch_usd_feed.py
@@ -1,6 +1,5 @@
 from telliot_feeds.datafeed import DataFeed
 from telliot_feeds.queries.price.spot_price import SpotPrice
-from telliot_feeds.sources.price.spot.coinbase import CoinbaseSpotPriceSource
 from telliot_feeds.sources.price.spot.coingecko import CoinGeckoSpotPriceSource
 from telliot_feeds.sources.price.spot.kraken import KrakenSpotPriceSource
 from telliot_feeds.sources.price_aggregator import PriceAggregator
@@ -13,7 +12,6 @@ bch_usd_median_feed = DataFeed(
         algorithm="median",
         sources=[
             CoinGeckoSpotPriceSource(asset="bch", currency="usd"),
-            CoinbaseSpotPriceSource(asset="bch", currency="usd"),
             KrakenSpotPriceSource(asset="bch", currency="usd"),
         ],
     ),

--- a/src/telliot_feeds/feeds/btc_usd_feed.py
+++ b/src/telliot_feeds/feeds/btc_usd_feed.py
@@ -1,7 +1,6 @@
 from telliot_feeds.datafeed import DataFeed
 from telliot_feeds.queries.price.spot_price import SpotPrice
 from telliot_feeds.sources.price.spot.binance import BinanceSpotPriceSource
-from telliot_feeds.sources.price.spot.coinbase import CoinbaseSpotPriceSource
 from telliot_feeds.sources.price.spot.coingecko import CoinGeckoSpotPriceSource
 from telliot_feeds.sources.price.spot.gemini import GeminiSpotPriceSource
 from telliot_feeds.sources.price.spot.kraken import KrakenSpotPriceSource
@@ -16,7 +15,6 @@ btc_usd_median_feed = DataFeed(
         sources=[
             CoinGeckoSpotPriceSource(asset="btc", currency="usd"),
             BinanceSpotPriceSource(asset="btc", currency="usdt"),
-            CoinbaseSpotPriceSource(asset="btc", currency="usd"),
             GeminiSpotPriceSource(asset="btc", currency="usd"),
             KrakenSpotPriceSource(asset="xbt", currency="usd"),
         ],

--- a/src/telliot_feeds/feeds/comp_usd_feed.py
+++ b/src/telliot_feeds/feeds/comp_usd_feed.py
@@ -1,6 +1,5 @@
 from telliot_feeds.datafeed import DataFeed
 from telliot_feeds.queries.price.spot_price import SpotPrice
-from telliot_feeds.sources.price.spot.coinbase import CoinbaseSpotPriceSource
 from telliot_feeds.sources.price.spot.coingecko import CoinGeckoSpotPriceSource
 from telliot_feeds.sources.price.spot.gemini import GeminiSpotPriceSource
 from telliot_feeds.sources.price_aggregator import PriceAggregator
@@ -13,7 +12,6 @@ comp_usd_median_feed = DataFeed(
         algorithm="median",
         sources=[
             CoinGeckoSpotPriceSource(asset="comp", currency="usd"),
-            CoinbaseSpotPriceSource(asset="comp", currency="usd"),
             GeminiSpotPriceSource(asset="comp", currency="usd"),
         ],
     ),

--- a/src/telliot_feeds/feeds/crv_usd_feed.py
+++ b/src/telliot_feeds/feeds/crv_usd_feed.py
@@ -1,6 +1,5 @@
 from telliot_feeds.datafeed import DataFeed
 from telliot_feeds.queries.price.spot_price import SpotPrice
-from telliot_feeds.sources.price.spot.coinbase import CoinbaseSpotPriceSource
 from telliot_feeds.sources.price.spot.coingecko import CoinGeckoSpotPriceSource
 from telliot_feeds.sources.price.spot.kraken import KrakenSpotPriceSource
 from telliot_feeds.sources.price_aggregator import PriceAggregator
@@ -13,7 +12,6 @@ crv_usd_median_feed = DataFeed(
         algorithm="median",
         sources=[
             CoinGeckoSpotPriceSource(asset="crv", currency="usd"),
-            CoinbaseSpotPriceSource(asset="crv", currency="usd"),
             KrakenSpotPriceSource(asset="crv", currency="usd"),
         ],
     ),

--- a/src/telliot_feeds/feeds/dai_usd_feed.py
+++ b/src/telliot_feeds/feeds/dai_usd_feed.py
@@ -1,7 +1,6 @@
 from telliot_feeds.datafeed import DataFeed
 from telliot_feeds.queries.price.spot_price import SpotPrice
 from telliot_feeds.sources.price.spot.binance import BinanceSpotPriceSource
-from telliot_feeds.sources.price.spot.coinbase import CoinbaseSpotPriceSource
 from telliot_feeds.sources.price.spot.coingecko import CoinGeckoSpotPriceSource
 from telliot_feeds.sources.price.spot.gemini import GeminiSpotPriceSource
 from telliot_feeds.sources.price.spot.uniswapV3 import UniswapV3PriceSource
@@ -15,7 +14,6 @@ dai_usd_median_feed = DataFeed(
         algorithm="median",
         sources=[
             CoinGeckoSpotPriceSource(asset="dai", currency="usd"),
-            CoinbaseSpotPriceSource(asset="dai", currency="usd"),
             BinanceSpotPriceSource(asset="dai", currency="usdt"),
             GeminiSpotPriceSource(asset="dai", currency="usd"),
             UniswapV3PriceSource(asset="dai", currency="usd"),

--- a/src/telliot_feeds/feeds/doge_usd_feed.py
+++ b/src/telliot_feeds/feeds/doge_usd_feed.py
@@ -1,6 +1,5 @@
 from telliot_feeds.datafeed import DataFeed
 from telliot_feeds.queries.price.spot_price import SpotPrice
-from telliot_feeds.sources.price.spot.coinbase import CoinbaseSpotPriceSource
 from telliot_feeds.sources.price.spot.coingecko import CoinGeckoSpotPriceSource
 from telliot_feeds.sources.price.spot.gemini import GeminiSpotPriceSource
 from telliot_feeds.sources.price_aggregator import PriceAggregator
@@ -13,7 +12,6 @@ doge_usd_median_feed = DataFeed(
         algorithm="median",
         sources=[
             CoinGeckoSpotPriceSource(asset="doge", currency="usd"),
-            CoinbaseSpotPriceSource(asset="doge", currency="usd"),
             GeminiSpotPriceSource(asset="doge", currency="usd"),
         ],
     ),

--- a/src/telliot_feeds/feeds/dot_usd_feed.py
+++ b/src/telliot_feeds/feeds/dot_usd_feed.py
@@ -1,6 +1,5 @@
 from telliot_feeds.datafeed import DataFeed
 from telliot_feeds.queries.price.spot_price import SpotPrice
-from telliot_feeds.sources.price.spot.coinbase import CoinbaseSpotPriceSource
 from telliot_feeds.sources.price.spot.coingecko import CoinGeckoSpotPriceSource
 from telliot_feeds.sources.price.spot.gemini import GeminiSpotPriceSource
 from telliot_feeds.sources.price_aggregator import PriceAggregator
@@ -13,7 +12,6 @@ dot_usd_median_feed = DataFeed(
         algorithm="median",
         sources=[
             CoinGeckoSpotPriceSource(asset="dot", currency="usd"),
-            CoinbaseSpotPriceSource(asset="dot", currency="usd"),
             GeminiSpotPriceSource(asset="dot", currency="usd"),
         ],
     ),

--- a/src/telliot_feeds/feeds/eth_btc_feed.py
+++ b/src/telliot_feeds/feeds/eth_btc_feed.py
@@ -1,7 +1,6 @@
 from telliot_feeds.datafeed import DataFeed
 from telliot_feeds.queries.price.spot_price import SpotPrice
 from telliot_feeds.sources.price.spot.binance import BinanceSpotPriceSource
-from telliot_feeds.sources.price.spot.coinbase import CoinbaseSpotPriceSource
 from telliot_feeds.sources.price.spot.coingecko import CoinGeckoSpotPriceSource
 from telliot_feeds.sources.price.spot.gemini import GeminiSpotPriceSource
 from telliot_feeds.sources.price_aggregator import PriceAggregator
@@ -15,7 +14,6 @@ eth_btc_median_feed = DataFeed(
         sources=[
             CoinGeckoSpotPriceSource(asset="eth", currency="btc"),
             BinanceSpotPriceSource(asset="eth", currency="btc"),
-            CoinbaseSpotPriceSource(asset="eth", currency="btc"),
             GeminiSpotPriceSource(asset="eth", currency="btc"),
         ],
     ),

--- a/src/telliot_feeds/feeds/eth_usd_feed.py
+++ b/src/telliot_feeds/feeds/eth_usd_feed.py
@@ -1,6 +1,5 @@
 from telliot_feeds.datafeed import DataFeed
 from telliot_feeds.queries.price.spot_price import SpotPrice
-from telliot_feeds.sources.price.spot.coinbase import CoinbaseSpotPriceSource
 from telliot_feeds.sources.price.spot.coingecko import CoinGeckoSpotPriceSource
 from telliot_feeds.sources.price.spot.gemini import GeminiSpotPriceSource
 from telliot_feeds.sources.price.spot.kraken import KrakenSpotPriceSource
@@ -14,7 +13,6 @@ eth_usd_median_feed = DataFeed(
         algorithm="median",
         sources=[
             CoinGeckoSpotPriceSource(asset="eth", currency="usd"),
-            CoinbaseSpotPriceSource(asset="eth", currency="usd"),
             GeminiSpotPriceSource(asset="eth", currency="usd"),
             KrakenSpotPriceSource(asset="eth", currency="usd"),
         ],

--- a/src/telliot_feeds/feeds/fil_usd_feed.py
+++ b/src/telliot_feeds/feeds/fil_usd_feed.py
@@ -1,6 +1,5 @@
 from telliot_feeds.datafeed import DataFeed
 from telliot_feeds.queries.price.spot_price import SpotPrice
-from telliot_feeds.sources.price.spot.coinbase import CoinbaseSpotPriceSource
 from telliot_feeds.sources.price.spot.coingecko import CoinGeckoSpotPriceSource
 from telliot_feeds.sources.price.spot.kraken import KrakenSpotPriceSource
 from telliot_feeds.sources.price_aggregator import PriceAggregator
@@ -12,7 +11,6 @@ fil_usd_median_feed = DataFeed(
         currency="usd",
         algorithm="median",
         sources=[
-            CoinbaseSpotPriceSource(asset="fil", currency="usd"),
             CoinGeckoSpotPriceSource(asset="fil", currency="usd"),
             KrakenSpotPriceSource(asset="fil", currency="usd"),
         ],

--- a/src/telliot_feeds/feeds/gno_usd_feed.py
+++ b/src/telliot_feeds/feeds/gno_usd_feed.py
@@ -1,6 +1,5 @@
 from telliot_feeds.datafeed import DataFeed
 from telliot_feeds.queries.price.spot_price import SpotPrice
-from telliot_feeds.sources.price.spot.coinbase import CoinbaseSpotPriceSource
 from telliot_feeds.sources.price.spot.coingecko import CoinGeckoSpotPriceSource
 from telliot_feeds.sources.price.spot.kraken import KrakenSpotPriceSource
 from telliot_feeds.sources.price_aggregator import PriceAggregator
@@ -13,7 +12,6 @@ gno_usd_median_feed = DataFeed(
         algorithm="median",
         sources=[
             CoinGeckoSpotPriceSource(asset="gno", currency="usd"),
-            CoinbaseSpotPriceSource(asset="gno", currency="usd"),
             KrakenSpotPriceSource(asset="gno", currency="usd"),
         ],
     ),

--- a/src/telliot_feeds/feeds/grt_usd_feed.py
+++ b/src/telliot_feeds/feeds/grt_usd_feed.py
@@ -1,6 +1,5 @@
 from telliot_feeds.datafeed import DataFeed
 from telliot_feeds.queries.price.spot_price import SpotPrice
-from telliot_feeds.sources.price.spot.coinbase import CoinbaseSpotPriceSource
 from telliot_feeds.sources.price.spot.coingecko import CoinGeckoSpotPriceSource
 from telliot_feeds.sources.price.spot.gemini import GeminiSpotPriceSource
 from telliot_feeds.sources.price_aggregator import PriceAggregator
@@ -13,7 +12,6 @@ grt_usd_median_feed = DataFeed(
         algorithm="median",
         sources=[
             CoinGeckoSpotPriceSource(asset="grt", currency="usd"),
-            CoinbaseSpotPriceSource(asset="grt", currency="usd"),
             GeminiSpotPriceSource(asset="grt", currency="usd"),
         ],
     ),

--- a/src/telliot_feeds/feeds/link_usd_feed.py
+++ b/src/telliot_feeds/feeds/link_usd_feed.py
@@ -1,6 +1,5 @@
 from telliot_feeds.datafeed import DataFeed
 from telliot_feeds.queries.price.spot_price import SpotPrice
-from telliot_feeds.sources.price.spot.coinbase import CoinbaseSpotPriceSource
 from telliot_feeds.sources.price.spot.coingecko import CoinGeckoSpotPriceSource
 from telliot_feeds.sources.price.spot.kraken import KrakenSpotPriceSource
 from telliot_feeds.sources.price_aggregator import PriceAggregator
@@ -13,7 +12,6 @@ link_usd_median_feed = DataFeed(
         algorithm="median",
         sources=[
             CoinGeckoSpotPriceSource(asset="link", currency="usd"),
-            CoinbaseSpotPriceSource(asset="link", currency="usd"),
             KrakenSpotPriceSource(asset="link", currency="usd"),
         ],
     ),

--- a/src/telliot_feeds/feeds/ltc_usd_feed.py
+++ b/src/telliot_feeds/feeds/ltc_usd_feed.py
@@ -1,6 +1,5 @@
 from telliot_feeds.datafeed import DataFeed
 from telliot_feeds.queries.price.spot_price import SpotPrice
-from telliot_feeds.sources.price.spot.coinbase import CoinbaseSpotPriceSource
 from telliot_feeds.sources.price.spot.coingecko import CoinGeckoSpotPriceSource
 from telliot_feeds.sources.price.spot.gemini import GeminiSpotPriceSource
 from telliot_feeds.sources.price_aggregator import PriceAggregator
@@ -13,7 +12,6 @@ ltc_usd_median_feed = DataFeed(
         algorithm="median",
         sources=[
             CoinGeckoSpotPriceSource(asset="ltc", currency="usd"),
-            CoinbaseSpotPriceSource(asset="ltc", currency="usd"),
             GeminiSpotPriceSource(asset="ltc", currency="usd"),
         ],
     ),

--- a/src/telliot_feeds/feeds/matic_usd_feed.py
+++ b/src/telliot_feeds/feeds/matic_usd_feed.py
@@ -1,7 +1,6 @@
 from telliot_feeds.datafeed import DataFeed
 from telliot_feeds.queries.price.spot_price import SpotPrice
 from telliot_feeds.sources.price.spot.binance import BinanceSpotPriceSource
-from telliot_feeds.sources.price.spot.coinbase import CoinbaseSpotPriceSource
 from telliot_feeds.sources.price.spot.coingecko import CoinGeckoSpotPriceSource
 from telliot_feeds.sources.price.spot.gemini import GeminiSpotPriceSource
 from telliot_feeds.sources.price.spot.kraken import KrakenSpotPriceSource
@@ -16,7 +15,6 @@ matic_usd_median_feed = DataFeed(
         sources=[
             CoinGeckoSpotPriceSource(asset="matic", currency="usd"),
             BinanceSpotPriceSource(asset="matic", currency="usdt"),
-            CoinbaseSpotPriceSource(asset="matic", currency="usd"),
             GeminiSpotPriceSource(asset="matic", currency="usd"),
             KrakenSpotPriceSource(asset="matic", currency="usd"),
         ],

--- a/src/telliot_feeds/feeds/mkr_usd_feed.py
+++ b/src/telliot_feeds/feeds/mkr_usd_feed.py
@@ -1,7 +1,6 @@
 from telliot_feeds.datafeed import DataFeed
 from telliot_feeds.queries.price.spot_price import SpotPrice
 from telliot_feeds.sources.price.spot.binance import BinanceSpotPriceSource
-from telliot_feeds.sources.price.spot.coinbase import CoinbaseSpotPriceSource
 from telliot_feeds.sources.price.spot.coingecko import CoinGeckoSpotPriceSource
 from telliot_feeds.sources.price.spot.gemini import GeminiSpotPriceSource
 from telliot_feeds.sources.price.spot.kraken import KrakenSpotPriceSource
@@ -16,7 +15,6 @@ mkr_usd_median_feed = DataFeed(
         sources=[
             CoinGeckoSpotPriceSource(asset="mkr", currency="usd"),
             BinanceSpotPriceSource(asset="mkr", currency="usdt"),
-            CoinbaseSpotPriceSource(asset="mkr", currency="usd"),
             GeminiSpotPriceSource(asset="mkr", currency="usd"),
             KrakenSpotPriceSource(asset="mkr", currency="usd"),
         ],

--- a/src/telliot_feeds/feeds/op_usd_feed.py
+++ b/src/telliot_feeds/feeds/op_usd_feed.py
@@ -1,7 +1,7 @@
 from telliot_feeds.datafeed import DataFeed
 from telliot_feeds.queries.price.spot_price import SpotPrice
-from telliot_feeds.sources.price.spot.coinbase import CoinbaseSpotPriceSource
 from telliot_feeds.sources.price.spot.coingecko import CoinGeckoSpotPriceSource
+from telliot_feeds.sources.price.spot.coinpaprika import CoinpaprikaSpotPriceSource
 from telliot_feeds.sources.price_aggregator import PriceAggregator
 
 op_usd_median_feed = DataFeed(
@@ -12,7 +12,7 @@ op_usd_median_feed = DataFeed(
         algorithm="median",
         sources=[
             CoinGeckoSpotPriceSource(asset="op", currency="usd"),
-            CoinbaseSpotPriceSource(asset="op", currency="usd"),
+            CoinpaprikaSpotPriceSource(asset="op-optimism", currency="usd"),
         ],
     ),
 )

--- a/src/telliot_feeds/feeds/rai_usd_feed.py
+++ b/src/telliot_feeds/feeds/rai_usd_feed.py
@@ -2,8 +2,8 @@ import asyncio
 
 from telliot_feeds.datafeed import DataFeed
 from telliot_feeds.queries.price.spot_price import SpotPrice
-from telliot_feeds.sources.price.spot.coinbase import CoinbaseSpotPriceSource
 from telliot_feeds.sources.price.spot.coingecko import CoinGeckoSpotPriceSource
+from telliot_feeds.sources.price.spot.coinpaprika import CoinpaprikaSpotPriceSource
 from telliot_feeds.sources.price_aggregator import PriceAggregator
 
 
@@ -15,7 +15,7 @@ rai_usd_median_feed = DataFeed(
         algorithm="median",
         sources=[
             CoinGeckoSpotPriceSource(asset="rai", currency="usd"),
-            CoinbaseSpotPriceSource(asset="rai", currency="usd"),
+            CoinpaprikaSpotPriceSource(asset="rai-rai-reflex-index", currency="usd"),
         ],
     ),
 )

--- a/src/telliot_feeds/feeds/shib_usd_feed.py
+++ b/src/telliot_feeds/feeds/shib_usd_feed.py
@@ -1,6 +1,5 @@
 from telliot_feeds.datafeed import DataFeed
 from telliot_feeds.queries.price.spot_price import SpotPrice
-from telliot_feeds.sources.price.spot.coinbase import CoinbaseSpotPriceSource
 from telliot_feeds.sources.price.spot.coingecko import CoinGeckoSpotPriceSource
 from telliot_feeds.sources.price.spot.gemini import GeminiSpotPriceSource
 from telliot_feeds.sources.price_aggregator import PriceAggregator
@@ -13,7 +12,6 @@ shib_usd_median_feed = DataFeed(
         algorithm="median",
         sources=[
             CoinGeckoSpotPriceSource(asset="shib", currency="usd"),
-            CoinbaseSpotPriceSource(asset="shib", currency="usd"),
             GeminiSpotPriceSource(asset="shib", currency="usd"),
         ],
     ),

--- a/src/telliot_feeds/feeds/sushi_usd_feed.py
+++ b/src/telliot_feeds/feeds/sushi_usd_feed.py
@@ -1,7 +1,6 @@
 from telliot_feeds.datafeed import DataFeed
 from telliot_feeds.queries.price.spot_price import SpotPrice
 from telliot_feeds.sources.price.spot.binance import BinanceSpotPriceSource
-from telliot_feeds.sources.price.spot.coinbase import CoinbaseSpotPriceSource
 from telliot_feeds.sources.price.spot.coingecko import CoinGeckoSpotPriceSource
 from telliot_feeds.sources.price.spot.gemini import GeminiSpotPriceSource
 from telliot_feeds.sources.price.spot.kraken import KrakenSpotPriceSource
@@ -16,7 +15,6 @@ sushi_usd_median_feed = DataFeed(
         sources=[
             CoinGeckoSpotPriceSource(asset="sushi", currency="usd"),
             BinanceSpotPriceSource(asset="sushi", currency="usdt"),
-            CoinbaseSpotPriceSource(asset="sushi", currency="usd"),
             GeminiSpotPriceSource(asset="sushi", currency="usd"),
             KrakenSpotPriceSource(asset="sushi", currency="usd"),
         ],

--- a/src/telliot_feeds/feeds/trb_usd_feed.py
+++ b/src/telliot_feeds/feeds/trb_usd_feed.py
@@ -1,7 +1,6 @@
 """Datafeed for current price of TRB in USD."""
 from telliot_feeds.datafeed import DataFeed
 from telliot_feeds.queries.price.spot_price import SpotPrice
-from telliot_feeds.sources.price.spot.coinbase import CoinbaseSpotPriceSource
 from telliot_feeds.sources.price.spot.coingecko import CoinGeckoSpotPriceSource
 from telliot_feeds.sources.price.spot.coinpaprika import CoinpaprikaSpotPriceSource
 from telliot_feeds.sources.price_aggregator import PriceAggregator
@@ -14,7 +13,6 @@ trb_usd_median_feed = DataFeed(
         algorithm="median",
         sources=[
             CoinGeckoSpotPriceSource(asset="trb", currency="usd"),
-            CoinbaseSpotPriceSource(asset="trb", currency="usd"),
             CoinpaprikaSpotPriceSource(asset="trb-tellor", currency="usd"),
         ],
     ),

--- a/src/telliot_feeds/feeds/uni_usd_feed.py
+++ b/src/telliot_feeds/feeds/uni_usd_feed.py
@@ -1,6 +1,5 @@
 from telliot_feeds.datafeed import DataFeed
 from telliot_feeds.queries.price.spot_price import SpotPrice
-from telliot_feeds.sources.price.spot.coinbase import CoinbaseSpotPriceSource
 from telliot_feeds.sources.price.spot.coingecko import CoinGeckoSpotPriceSource
 from telliot_feeds.sources.price.spot.gemini import GeminiSpotPriceSource
 from telliot_feeds.sources.price_aggregator import PriceAggregator
@@ -13,7 +12,6 @@ uni_usd_median_feed = DataFeed(
         algorithm="median",
         sources=[
             CoinGeckoSpotPriceSource(asset="uni", currency="usd"),
-            CoinbaseSpotPriceSource(asset="uni", currency="usd"),
             GeminiSpotPriceSource(asset="uni", currency="usd"),
         ],
     ),

--- a/src/telliot_feeds/feeds/usdt_usd_feed.py
+++ b/src/telliot_feeds/feeds/usdt_usd_feed.py
@@ -1,7 +1,6 @@
 from telliot_feeds.datafeed import DataFeed
 from telliot_feeds.queries.price.spot_price import SpotPrice
 from telliot_feeds.sources.price.spot.agni import agniFinancePriceSource
-from telliot_feeds.sources.price.spot.coinbase import CoinbaseSpotPriceSource
 from telliot_feeds.sources.price.spot.coingecko import CoinGeckoSpotPriceSource
 from telliot_feeds.sources.price.spot.gemini import GeminiSpotPriceSource
 from telliot_feeds.sources.price_aggregator import PriceAggregator
@@ -14,7 +13,6 @@ usdt_usd_median_feed = DataFeed(
         algorithm="median",
         sources=[
             CoinGeckoSpotPriceSource(asset="usdt", currency="usd"),
-            CoinbaseSpotPriceSource(asset="usdt", currency="usd"),
             GeminiSpotPriceSource(asset="usdt", currency="usd"),
             agniFinancePriceSource(asset="usdt", currency="usd"),
         ],

--- a/src/telliot_feeds/feeds/xdai_usd_feed.py
+++ b/src/telliot_feeds/feeds/xdai_usd_feed.py
@@ -1,7 +1,7 @@
 from telliot_feeds.datafeed import DataFeed
 from telliot_feeds.queries.price.spot_price import SpotPrice
-from telliot_feeds.sources.price.spot.coinbase import CoinbaseSpotPriceSource
 from telliot_feeds.sources.price.spot.coingecko import CoinGeckoSpotPriceSource
+from telliot_feeds.sources.price.spot.coinpaprika import CoinpaprikaSpotPriceSource
 from telliot_feeds.sources.price_aggregator import PriceAggregator
 
 xdai_usd_median_feed = DataFeed(
@@ -12,7 +12,7 @@ xdai_usd_median_feed = DataFeed(
         algorithm="median",
         sources=[
             CoinGeckoSpotPriceSource(asset="xdai", currency="usd"),
-            CoinbaseSpotPriceSource(asset="dai", currency="usd"),
+            CoinpaprikaSpotPriceSource(asset="xdai-xdai", currency="usd"),
         ],
     ),
 )

--- a/src/telliot_feeds/feeds/yfi_usd_feed.py
+++ b/src/telliot_feeds/feeds/yfi_usd_feed.py
@@ -1,7 +1,7 @@
 from telliot_feeds.datafeed import DataFeed
 from telliot_feeds.queries.price.spot_price import SpotPrice
-from telliot_feeds.sources.price.spot.coinbase import CoinbaseSpotPriceSource
 from telliot_feeds.sources.price.spot.coingecko import CoinGeckoSpotPriceSource
+from telliot_feeds.sources.price.spot.coinpaprika import CoinpaprikaSpotPriceSource
 from telliot_feeds.sources.price.spot.gemini import GeminiSpotPriceSource
 from telliot_feeds.sources.price_aggregator import PriceAggregator
 
@@ -13,7 +13,7 @@ yfi_usd_median_feed = DataFeed(
         algorithm="median",
         sources=[
             CoinGeckoSpotPriceSource(asset="yfi", currency="usd"),
-            CoinbaseSpotPriceSource(asset="yfi", currency="usd"),
+            CoinpaprikaSpotPriceSource(asset="yfi-yearnfinance", currency="usd"),
             GeminiSpotPriceSource(asset="yfi", currency="usd"),
         ],
     ),

--- a/src/telliot_feeds/queries/price/spot_price.py
+++ b/src/telliot_feeds/queries/price/spot_price.py
@@ -13,7 +13,7 @@ from telliot_feeds.queries.abi_query import AbiQuery
 
 logger = logging.getLogger(__name__)
 
-CURRENCIES = ["usd", "jpy", "eth", "btc", "usdc"]
+CURRENCIES = ["usd", "jpy", "eth", "btc"]
 SPOT_PRICE_PAIRS = [
     "ETH/USD",
     "BTC/USD",

--- a/src/telliot_feeds/queries/price/spot_price.py
+++ b/src/telliot_feeds/queries/price/spot_price.py
@@ -13,7 +13,7 @@ from telliot_feeds.queries.abi_query import AbiQuery
 
 logger = logging.getLogger(__name__)
 
-CURRENCIES = ["usd", "jpy", "eth", "btc"]
+CURRENCIES = ["usd", "jpy", "eth", "btc", "usdc"]
 SPOT_PRICE_PAIRS = [
     "ETH/USD",
     "BTC/USD",

--- a/tests/feeds/test_dai_usd_feed.py
+++ b/tests/feeds/test_dai_usd_feed.py
@@ -12,7 +12,7 @@ async def test_dai_usd_median_feed(caplog):
 
     assert v is not None
     assert v > 0
-    assert "sources used in aggregate: 4" in caplog.text.lower()
+    assert "sources used in aggregate: 3" in caplog.text.lower()
     print(f"DAI/USD Price: {v}")
 
     # Get list of data sources from sources dict

--- a/tests/feeds/test_eth_btc_feed.py
+++ b/tests/feeds/test_eth_btc_feed.py
@@ -13,7 +13,7 @@ async def test_eth_btc_median_feed(caplog):
     assert v is not None
     assert v > 0
     assert (  # sometimes only 3 sources are used bc binance restricts locations
-        "sources used in aggregate: 4" in caplog.text.lower() or "sources used in aggregate: 3" in caplog.text.lower()
+        "sources used in aggregate: 2" in caplog.text.lower() or "sources used in aggregate: 3" in caplog.text.lower()
     )
     print(f"ETH/BTC Price: {v}")
 

--- a/tests/feeds/test_eth_usd_feed.py
+++ b/tests/feeds/test_eth_usd_feed.py
@@ -13,7 +13,7 @@ async def test_eth_usd_median_feed(caplog):
     assert v is not None
     assert v > 0
     assert (
-        "sources used in aggregate: 4" in caplog.text.lower() or "sources used in aggregate: 5" in caplog.text.lower()
+        "sources used in aggregate: 3" in caplog.text.lower() or "sources used in aggregate: 5" in caplog.text.lower()
     )
     print(f"ETH/USD Price: {v}")
 


### PR DESCRIPTION
### Summary
Coinbase api removed because it's been deprecated.

### Checklist
This pull request is:
- [x] A code fix