### PR TITLE
switch to unstablev1 action branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Set up Python 3.9
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v1
       with:
         python-version: 3.9
 
@@ -36,13 +36,13 @@ jobs:
         .
     - name: Publish telliot-feeds to Test PyPI
       if: "github.event.release.prerelease"
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@unstable/v1
       with:
         password: ${{ secrets.TELLIOT_FEEDS_TEST_PYPI_API_TOKEN }}
         repository_url: https://test.pypi.org/legacy/
 
     - name: Publish telliot-feeds to PyPI
       if: "!github.event.release.prerelease"
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@unstable/v1
       with:
         password: ${{ secrets.TELLIOT_FEEDS_PYPI_API_TOKEN }}


### PR DESCRIPTION
### Summary
use v1 setup-python version to unstable/v1 branch as shown here https://github.com/pypa/gh-action-pypi-publish/tree/unstable/v1