### PR TITLE
curve fi url change

### DIFF
--- a/src/telliot_feeds/sources/price/spot/curvefi.py
+++ b/src/telliot_feeds/sources/price/spot/curvefi.py
@@ -25,7 +25,7 @@ class CurveFinanceSpotPriceService(WebPriceService):
 
     def __init__(self, **kwargs: Any) -> None:
         kwargs["name"] = "CurveFinance Price Service"
-        kwargs["url"] = "https://api.curve.fi"
+        kwargs["url"] = "https://api.curve.finance"
         super().__init__(**kwargs)
 
     async def get_price(self, asset: str, currency: str) -> OptionalDataPoint[float]:

--- a/src/telliot_feeds/sources/price/spot/curvefiprice.py
+++ b/src/telliot_feeds/sources/price/spot/curvefiprice.py
@@ -34,7 +34,7 @@ class CurveFiUSDPriceService(WebPriceService):
 
     def __init__(self, **kwargs: Any) -> None:
         kwargs["name"] = "Curve-Prices Service"
-        kwargs["url"] = "https://prices.curve.fi/v1/usd_price"
+        kwargs["url"] = "https://prices.curve.finance/v1/usd_price"
         super().__init__(**kwargs)
 
     async def get_price(self, asset: str, currency: str) -> OptionalDataPoint[float]:


### PR DESCRIPTION
### Summary
Fix for curve finance api urls.
"curve.fi" is now "curve.finance"